### PR TITLE
Fix #37, Add cancellation point to idle task

### DIFF
--- a/fsw/src/hs_custom.c
+++ b/fsw/src/hs_custom.c
@@ -75,6 +75,9 @@ void HS_IdleTask(void)
 
         /* Call the Utilization Tracking function */
         HS_UtilizationIncrement();
+
+        /* Thread cancellation point/give up CPU */
+        OS_TaskDelay(0);
     }
 
     return;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #37 

Just adds cancellation point to the idle task

**Testing performed**
CI, and confirmed cFS exits cleanly with Ctrl-C

**Expected behavior changes**
HS idle task now exits cleanly

**System(s) tested on**
CI and Linux

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC

@excaliburtb