### PR TITLE
Fix #50, Apply consistent Event ID names to common events

### DIFF
--- a/config/default_hs_fcncodes.h
+++ b/config/default_hs_fcncodes.h
@@ -60,7 +60,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -82,7 +82,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will be cleared
- *       - The #HS_RESET_DBG_EID debug event message will be
+ *       - The #HS_RESET_INF_EID debug event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -91,7 +91,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -123,7 +123,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -155,7 +155,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -187,7 +187,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -219,7 +219,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -251,7 +251,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -283,7 +283,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -315,7 +315,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -347,7 +347,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -379,7 +379,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -411,7 +411,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
- *       - Error specific event message #HS_LEN_ERR_EID
+ *       - Error specific event message #HS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None

--- a/fsw/inc/hs_eventids.h
+++ b/fsw/inc/hs_eventids.h
@@ -39,7 +39,7 @@
  *  This event message is issued when the CFS Health and Safety has
  *  completed initialization.
  */
-#define HS_INIT_EID 1
+#define HS_INIT_INF_EID 1
 
 /**
  * \brief HS Application Fatal Termination Event ID
@@ -76,7 +76,7 @@
  *  is unable to create its command pipe via the #CFE_SB_CreatePipe
  *  API
  */
-#define HS_CR_CMD_PIPE_ERR_EID 4
+#define HS_CR_PIPE_ERR_EID 4
 
 /**
  * \brief HS Create Software Bus Event Pipe Failed Event ID
@@ -297,7 +297,7 @@
  *  This event message is issued when a ground command message is received
  *  with a message length that doesn't match the expected value.
  */
-#define HS_LEN_ERR_EID 22
+#define HS_CMD_LEN_ERR_EID 22
 
 /**
  * \brief HS No-op Command Event ID
@@ -313,14 +313,14 @@
 /**
  * \brief HS Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when a reset counters command has
  *  been received.
  */
-#define HS_RESET_DBG_EID 24
+#define HS_RESET_INF_EID 24
 
 /**
  * \brief HS Enable Application Monitoring Command Event ID

--- a/fsw/src/hs_app.c
+++ b/fsw/src/hs_app.c
@@ -330,7 +330,7 @@ CFE_Status_t HS_AppInit(void)
     /*
     ** Application initialization event
     */
-    CFE_EVS_SendEvent(HS_INIT_EID, CFE_EVS_EventType_INFORMATION, "HS Initialized.  Version %d.%d.%d.%d",
+    CFE_EVS_SendEvent(HS_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "HS Initialized.  Version %d.%d.%d.%d",
                       HS_MAJOR_VERSION, HS_MINOR_VERSION, HS_REVISION, HS_MISSION_REV);
 
     return Status;
@@ -353,7 +353,7 @@ CFE_Status_t HS_SbInit(void)
     Status = CFE_SB_CreatePipe(&HS_AppData.CmdPipe, HS_CMD_PIPE_DEPTH, HS_CMD_PIPE_NAME);
     if (Status != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(HS_CR_CMD_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "Error Creating SB Command Pipe,RC=0x%08X",
+        CFE_EVS_SendEvent(HS_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, "Error Creating SB Command Pipe,RC=0x%08X",
                           (unsigned int)Status);
         return Status;
     }

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -212,7 +212,7 @@ CFE_Status_t HS_ResetCmd(const HS_ResetCmd_t *BufPtr)
 {
     HS_ResetCounters();
 
-    CFE_EVS_SendEvent(HS_RESET_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(HS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
     return CFE_SUCCESS;
 }
 

--- a/fsw/src/hs_dispatch.c
+++ b/fsw/src/hs_dispatch.c
@@ -71,7 +71,7 @@ bool HS_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
             /*
             ** All other cases, increment error counter
             */
-            CFE_EVS_SendEvent(HS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(HS_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode, (int)ActualLength,
                               (int)ExpectedLength);

--- a/fsw/src/hs_dispatch.h
+++ b/fsw/src/hs_dispatch.h
@@ -67,7 +67,7 @@ void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr);
  *  \retval true  Length matches expected
  *  \retval false Length does not match expected
  *
- *  \sa #HS_LEN_ERR_EID
+ *  \sa #HS_CMD_LEN_ERR_EID
  */
 bool HS_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 

--- a/unit-test/hs_app_tests.c
+++ b/unit-test/hs_app_tests.c
@@ -302,7 +302,7 @@ void HS_AppMain_Test_NominalRcvMsgError(void)
     UtAssert_True(HS_AppData.EventsMonitoredCount == 1, "HS_AppData.EventsMonitoredCount == 1");
 
     /* Verify results */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_APP_EXIT_EID);
@@ -423,7 +423,7 @@ void HS_AppMain_Test_SBSubscribeEVSLongError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_SUB_LONG_EVS_ERR_EID);
@@ -474,7 +474,7 @@ void HS_AppMain_Test_SBSubscribeEVSShortError(void)
     HS_AppMain();
 
     /* Verify results */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_SUB_SHORT_EVS_ERR_EID);
@@ -559,7 +559,7 @@ void HS_AppMain_Test_StateDisabled(void)
     HS_AppMain();
 
     /* Verify results */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -736,7 +736,7 @@ void HS_AppInit_Test_CorruptCDSResetsPerformed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
@@ -868,7 +868,7 @@ void HS_AppInit_Test_CorruptCDSNoEvent(void)
     UtAssert_True(HS_AppData.CurrentCPUHogState == HS_CPUHOG_DEFAULT_STATE,
                   "HS_AppData.CurrentCPUHogState == HS_CPUHOG_DEFAULT_STATE");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -916,7 +916,7 @@ void HS_AppInit_Test_RestoreCDSError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
@@ -972,7 +972,7 @@ void HS_AppInit_Test_DisableSavingToCDS(void)
     UtAssert_True(HS_AppData.CurrentCPUHogState == HS_CPUHOG_DEFAULT_STATE,
                   "HS_AppData.CurrentCPUHogState == HS_CPUHOG_DEFAULT_STATE");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1029,7 +1029,7 @@ void HS_AppInit_Test_SBInitError(void)
 
     /* This event message is not generated directly by the function under test, but it's useful to check for it to
      * ensure that an SB init error occurred rather than a TBL init error */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_CR_CMD_PIPE_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_CR_PIPE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1173,7 +1173,7 @@ void HS_SbInit_Test_CreateSBCmdPipeError(void)
     UT_SetDataBuffer(UT_KEY(CFE_SB_CreatePipe), &PipeId, sizeof(PipeId), false);
     UT_SetDataBuffer(UT_KEY(CFE_SB_CreatePipe), &PipeId, sizeof(PipeId), false);
 
-    /* Set CFE_SB_CreatePipe to return -1 on first call, to generate error HS_CR_CMD_PIPE_ERR_EID */
+    /* Set CFE_SB_CreatePipe to return -1 on first call, to generate error HS_CR_PIPE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_CreatePipe), 1, -1);
 
     /* Execute the function being tested */
@@ -1184,7 +1184,7 @@ void HS_SbInit_Test_CreateSBCmdPipeError(void)
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(HS_AppData.EventPipe));
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(HS_AppData.WakeupPipe));
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_CR_CMD_PIPE_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_CR_PIPE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -1034,7 +1034,7 @@ void HS_ResetCmd_Test(void)
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_RESET_DBG_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_RESET_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
 
     strCmpResult =

--- a/unit-test/hs_dispatch_tests.c
+++ b/unit-test/hs_dispatch_tests.c
@@ -86,7 +86,7 @@ void HS_VerifyMsgLength_Test(void)
     UtAssert_BOOL_FALSE(HS_VerifyMsgLength(&UT_CmdBuf.Msg, 2));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_UINT8_EQ(HS_AppData.CmdErrCount, 1);
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #50 
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt