### PR TITLE
Fix #52, Remove initializations causing Cppcheck errors

### DIFF
--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -154,8 +154,8 @@ void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
     CFE_ES_TaskInfo_t  TaskInfo;
     memset(&TaskInfo, 0, sizeof(TaskInfo));
 #endif
-    int32  Status     = CFE_SUCCESS;
-    uint32 TableIndex = 0;
+    int32  Status;
+    uint32 TableIndex;
 
     /*
     ** Verify message packet length

--- a/fsw/src/hs_custom.c
+++ b/fsw/src/hs_custom.c
@@ -263,12 +263,12 @@ void HS_UtilDiagReport(void)
 {
     uint32 DiagValue[HS_UTIL_TIME_DIAG_ARRAY_LENGTH];
     uint32 DiagCount[HS_UTIL_TIME_DIAG_ARRAY_LENGTH];
-    uint32 i         = 0;
-    uint32 j         = 0;
-    uint32 ThisValue = 0;
+    uint32 i = 0;
+    uint32 j;
+    uint32 ThisValue;
 
-    uint32 Ordinal         = 0;
-    uint32 NewOrdinalIndex = 0;
+    uint32 Ordinal;
+    uint32 NewOrdinalIndex;
     uint32 OutputValue[HS_UTIL_DIAG_REPORTS];
     uint32 OutputCount[HS_UTIL_DIAG_REPORTS];
     uint32 OutputOrdinal[HS_UTIL_DIAG_REPORTS];

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -44,10 +44,10 @@
 void HS_MonitorApplications(void)
 {
     CFE_ES_AppInfo_t AppInfo;
-    CFE_ES_AppId_t   AppId        = CFE_ES_APPID_UNDEFINED;
-    int32            Status       = CFE_SUCCESS;
-    uint32           TableIndex   = 0;
-    uint16           ActionType   = 0;
+    CFE_ES_AppId_t   AppId = CFE_ES_APPID_UNDEFINED;
+    int32            Status;
+    uint32           TableIndex = 0;
+    uint16           ActionType;
     uint32           MsgActsIndex = 0;
     CFE_SB_Buffer_t *BufPtr       = NULL;
 
@@ -222,10 +222,10 @@ void HS_MonitorApplications(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_MonitorEvent(const CFE_EVS_LongEventTlm_t *EventPtr)
 {
-    uint32           TableIndex   = 0;
-    int32            Status       = CFE_SUCCESS;
-    CFE_ES_AppId_t   AppId        = CFE_ES_APPID_UNDEFINED;
-    uint16           ActionType   = 0;
+    uint32           TableIndex = 0;
+    int32            Status     = CFE_SUCCESS;
+    CFE_ES_AppId_t   AppId      = CFE_ES_APPID_UNDEFINED;
+    uint16           ActionType;
     uint32           MsgActsIndex = 0;
     CFE_SB_Buffer_t *SendPtr      = NULL;
 
@@ -455,11 +455,11 @@ int32 HS_ValidateAMTable(void *TableData)
 
     int32  TableResult = CFE_SUCCESS;
     uint32 TableIndex  = 0;
-    int32  EntryResult = 0;
+    int32  EntryResult;
 
-    uint16 ActionType = 0;
-    uint16 CycleCount = 0;
-    uint16 NullTerm   = 0;
+    uint16 ActionType;
+    uint16 CycleCount;
+    uint16 NullTerm;
 
     uint32 GoodCount                = 0;
     uint32 BadCount                 = 0;
@@ -546,11 +546,11 @@ int32 HS_ValidateEMTable(void *TableData)
 
     int32  TableResult = CFE_SUCCESS;
     uint32 TableIndex  = 0;
-    int32  EntryResult = 0;
+    int32  EntryResult;
 
-    uint16 ActionType = 0;
-    uint16 EventID    = 0;
-    uint16 NullTerm   = 0;
+    uint16 ActionType;
+    uint16 EventID;
+    uint16 NullTerm;
 
     uint32 GoodCount                = 0;
     uint32 BadCount                 = 0;
@@ -731,8 +731,8 @@ int32 HS_ValidateMATable(void *TableData)
     int32  TableResult = CFE_SUCCESS;
     uint32 TableIndex  = 0;
     size_t Length      = 0;
-    uint16 EnableState = 0;
-    int32  EntryResult = 0;
+    uint16 EnableState;
+    int32  EntryResult;
 
     CFE_SB_MsgId_t   MessageID = CFE_SB_INVALID_MSG_ID;
     CFE_SB_Buffer_t *BufPtr    = (CFE_SB_Buffer_t *)NULL;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #52 
Note: all are local variables only.
In order of the errors reported in the issue report:

hs_cmds.c
`int32  Status = CFE_SUCCESS;`: The only uses of `Status` are after it has been set, and given that this is a `void` function, there seems no need to have it initialized to a default value at the top of the function.

hs_custom.c
`uint32 j = 0;`: `j` is assigned a value before each use, so this can be changed from an initialization to a declaration.
`uint32 ThisValue = 0;`: `ThisValue` is assigned a value before its use in a mutually exclusive `if`/`else` statement beginning on line 292. Therefore, this is also safe to change to declaration-only.
`uint32 Ordinal = 0;`: `Ordinal` is assigned a value before its first use (on line 327).
`uint32 NewOrdinalIndex = 0;`: `NewOrdinalIndex` is assigned a value on line 338 before its first use.

hs_monitors.c
In the `HS_MonitorApplications()` function:
`int32 Status = CFE_SUCCESS;`: `Status` is assigned a value (on line 65) before it is used, and this assignment covers all of its references. Given that this is a `void` function, there is no issue with someone trying to potentially return `Status` uninitialized if it doesn't get set somehow during the function logic (similar to the first case for `Status` in hs_cmds.c).
`uint16 ActionType = 0;`: `ActionType` is assigned a value (on line 58) before any and all of its references.

In the `HS_MonitorEvent()` function:
`uint16 ActionType = 0;`: `ActionType` is assigned a value (on line 234) before any and all of its references.

In the `HS_ValidateAMTable()` function:
`int32 EntryResult = 0;`: `EntryResult` is assigned a value (on line 482) before any and all of its references.
`uint16 ActionType = 0;`: `ActionType` is assigned a value (on line 479) before any and all of its references.
`uint16 CycleCount = 0;`: `CycleCount` is assigned a value (on line 480) before any and all of its references.
`uint16 NullTerm = 0;`: `NullTerm` is assigned a value (on line 481) before any and all of its references.

In the `HS_ValidateEMTable()` function:
`int32 EntryResult = 0;`: `EntryResult` is assigned a value (on line 573) before any and all of its references.
`uint16 ActionType = 0;`: `ActionType` is assigned a value (on line 570) before any and all of its references.
`uint16 EventID = 0;`: `EventID` is assigned a value (on line 571) before any and all of its references.
`uint16 NullTerm = 0;`: `NullTerm` is assigned a value (on line 572) before any and all of its references.

In the `HS_ValidateMATable()` function:
`uint16 EnableState = 0;`: `EnableState` is assigned a value (on line 758) before any and all of its references.
`int32 EntryResult = 0;`: `EntryResult` is assigned a value (on line 754) before any and all of its references.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.
Cppcheck now passes without error again.

**Contributor Info**
Avi @thnkslprpt