### PR TITLE
Fix #66, remove compiler extensions from tbldefs

### DIFF
--- a/fsw/tables/hs_amt.c
+++ b/fsw/tables/hs_amt.c
@@ -30,11 +30,10 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-static CFE_TBL_FileDef_t CFE_TBL_FileDef
-    __attribute__((__used__)) = {"HS_Default_AppMon_Tbl", HS_APP_NAME ".AppMon_Tbl", "HS AppMon Table", "hs_amt.tbl",
-                                 (sizeof(HS_AMTEntry_t) * HS_MAX_MONITORED_APPS)};
+CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_AppMon_Tbl", HS_APP_NAME ".AppMon_Tbl", "HS AppMon Table", "hs_amt.tbl",
+                                     (sizeof(HS_AMTEntry_t) * HS_MAX_MONITORED_APPS)};
 
-HS_AMTEntry_t HS_Default_AppMon_Tbl[HS_MAX_MONITORED_APPS] = {
+HS_AMTEntry_t HS_AppMon_Tbl[HS_MAX_MONITORED_APPS] = {
     /*          AppName                    NullTerm CycleCount     ActionType */
 
     /*   0 */ {"CFE_ES", 0, 10, HS_AMT_ACT_NOACT},

--- a/fsw/tables/hs_emt.c
+++ b/fsw/tables/hs_emt.c
@@ -30,11 +30,10 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-static CFE_TBL_FileDef_t CFE_TBL_FileDef
-    __attribute__((__used__)) = {"HS_Default_EventMon_Tbl", HS_APP_NAME ".EventMon_Tbl", "HS EventMon Table",
-                                 "hs_emt.tbl", (sizeof(HS_EMTEntry_t) * HS_MAX_MONITORED_EVENTS)};
+CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_EventMon_Tbl", HS_APP_NAME ".EventMon_Tbl", "HS EventMon Table", "hs_emt.tbl",
+                                     (sizeof(HS_EMTEntry_t) * HS_MAX_MONITORED_EVENTS)};
 
-HS_EMTEntry_t HS_Default_EventMon_Tbl[HS_MAX_MONITORED_EVENTS] = {
+HS_EMTEntry_t HS_EventMon_Tbl[HS_MAX_MONITORED_EVENTS] = {
     /*          AppName                    NullTerm EventID        ActionType */
 
     /*   0 */ {"CFE_ES", 0, 10, HS_EMT_ACT_NOACT},

--- a/fsw/tables/hs_mat.c
+++ b/fsw/tables/hs_mat.c
@@ -30,11 +30,10 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-static CFE_TBL_FileDef_t CFE_TBL_FileDef
-    __attribute__((__used__)) = {"HS_Default_MsgActs_Tbl", HS_APP_NAME ".MsgActs_Tbl", "HS MsgActs Table", "hs_mat.tbl",
-                                 (sizeof(HS_MATEntry_t) * HS_MAX_MSG_ACT_TYPES)};
+CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_MsgActs_Tbl", HS_APP_NAME ".MsgActs_Tbl", "HS MsgActs Table", "hs_mat.tbl",
+                                     (sizeof(HS_MATEntry_t) * HS_MAX_MSG_ACT_TYPES)};
 
-HS_MATEntry_t HS_Default_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
+HS_MATEntry_t HS_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
     /*          EnableState               Cooldown   Message */
 
     /*   0 */ {HS_MAT_STATE_DISABLED,

--- a/fsw/tables/hs_xct.c
+++ b/fsw/tables/hs_xct.c
@@ -30,10 +30,10 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_Default_ExeCount_Tbl", HS_APP_NAME ".ExeCount_Tbl", "HS ExeCount Table",
+CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_ExeCount_Tbl", HS_APP_NAME ".ExeCount_Tbl", "HS ExeCount Table",
                                      "hs_xct.tbl", (sizeof(HS_XCTEntry_t) * HS_MAX_EXEC_CNT_SLOTS)};
 
-HS_XCTEntry_t HS_Default_ExeCount_Tbl[HS_MAX_EXEC_CNT_SLOTS] = {
+HS_XCTEntry_t HS_ExeCount_Tbl[HS_MAX_EXEC_CNT_SLOTS] = {
     /*          ResourceName               NullTerm ResourceType              */
 
     /*   0 */ {"CFE_ES", 0, HS_XCT_TYPE_APP_MAIN},

--- a/fsw/tables/hs_xct.c
+++ b/fsw/tables/hs_xct.c
@@ -30,9 +30,8 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-static CFE_TBL_FileDef_t CFE_TBL_FileDef
-    __attribute__((__used__)) = {"HS_Default_ExeCount_Tbl", HS_APP_NAME ".ExeCount_Tbl", "HS ExeCount Table",
-                                 "hs_xct.tbl", (sizeof(HS_XCTEntry_t) * HS_MAX_EXEC_CNT_SLOTS)};
+CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_Default_ExeCount_Tbl", HS_APP_NAME ".ExeCount_Tbl", "HS ExeCount Table",
+                                     "hs_xct.tbl", (sizeof(HS_XCTEntry_t) * HS_MAX_EXEC_CNT_SLOTS)};
 
 HS_XCTEntry_t HS_Default_ExeCount_Tbl[HS_MAX_EXEC_CNT_SLOTS] = {
     /*          ResourceName               NullTerm ResourceType              */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Do not declare tables as "static" w/attribute "used", neither are needed, and build works fine without any special sauce.

This also makes the table name consistent by removing the "Default" in the name - it is still the same table, the name does not need to change just because it happens to be the default value.

Fixes #66

**Testing performed**
Build and run all tests
Run HS app and confirm normal startup, tables loaded

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

