### PR TITLE
Fix #69, Fix #73, remove conditional compiles from code

### DIFF
--- a/fsw/inc/hs_msg.h
+++ b/fsw/inc/hs_msg.h
@@ -111,9 +111,7 @@ typedef struct
     uint32 UtilCpuAvg;  /**< \brief Current CPU Utilization Average */
     uint32 UtilCpuPeak; /**< \brief Current CPU Utilization Peak */
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     uint32 ExeCounts[HS_MAX_EXEC_CNT_SLOTS]; /**< \brief Execution Counters */
-#endif
 } HS_HkPacket_t;
 
 /**\}*/

--- a/fsw/src/hs_app.c
+++ b/fsw/src/hs_app.c
@@ -214,12 +214,7 @@ int32 HS_AppInit(void)
     HS_AppData.CurrentAlivenessState = HS_ALIVENESS_DEFAULT_STATE;
     HS_AppData.CurrentCPUHogState    = HS_CPUHOG_DEFAULT_STATE;
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
-    HS_AppData.ExeCountState = HS_STATE_ENABLED;
-#else
-    HS_AppData.ExeCountState = HS_STATE_DISABLED;
-#endif
-
+    HS_AppData.ExeCountState  = HS_STATE_ENABLED;
     HS_AppData.MsgActsState   = HS_STATE_ENABLED;
     HS_AppData.AppMonLoaded   = HS_STATE_ENABLED;
     HS_AppData.EventMonLoaded = HS_STATE_ENABLED;
@@ -460,7 +455,6 @@ int32 HS_TblInit(void)
         return Status;
     }
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     /* Register The HS Execution Counters Table */
     TableSize = HS_MAX_EXEC_CNT_SLOTS * sizeof(HS_XCTEntry_t);
     Status    = CFE_TBL_Register(&HS_AppData.XCTableHandle, HS_XCT_TABLENAME, TableSize, CFE_TBL_OPT_DEFAULT,
@@ -486,7 +480,6 @@ int32 HS_TblInit(void)
             HS_AppData.HkPacket.ExeCounts[TableIndex] = HS_INVALID_EXECOUNT;
         }
     }
-#endif
 
     /* Load the HS Applications Monitor Table */
     Status = CFE_TBL_Load(HS_AppData.AMTableHandle, CFE_TBL_SRC_FILE, (const void *)HS_AMT_FILENAME);

--- a/fsw/src/hs_app.h
+++ b/fsw/src/hs_app.h
@@ -127,10 +127,8 @@ typedef struct
     CFE_TBL_Handle_t EMTableHandle; /**< \brief Events Monitor table handle */
     CFE_TBL_Handle_t MATableHandle; /**< \brief Message Actions table handle */
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     CFE_TBL_Handle_t XCTableHandle; /**< \brief Execution Counters table handle */
     HS_XCTEntry_t *  XCTablePtr;    /**< \brief Ptr to Execution Counters table entry */
-#endif
 
     HS_AMTEntry_t *AMTablePtr; /**< \brief Ptr to Apps Monitor table entry */
     HS_EMTEntry_t *EMTablePtr; /**< \brief Ptr to Events Monitor table entry */

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -147,15 +147,15 @@ void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
 {
     size_t         ExpectedLength = sizeof(HS_NoArgsCmd_t);
     CFE_ES_AppId_t AppId          = CFE_ES_APPID_UNDEFINED;
-#if HS_MAX_EXEC_CNT_SLOTS != 0
-    uint32             ExeCount  = 0;
-    CFE_ES_TaskId_t    TaskId    = CFE_ES_TASKID_UNDEFINED;
-    CFE_ES_CounterId_t CounterId = CFE_ES_COUNTERID_UNDEFINED;
+
+    uint32             ExeCount;
+    CFE_ES_TaskId_t    TaskId;
+    CFE_ES_CounterId_t CounterId;
     CFE_ES_TaskInfo_t  TaskInfo;
+    int32              Status;
+    uint32             TableIndex;
+
     memset(&TaskInfo, 0, sizeof(TaskInfo));
-#endif
-    int32  Status;
-    uint32 TableIndex;
 
     /*
     ** Verify message packet length
@@ -198,12 +198,10 @@ void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
         ** Build the HK status flags byte
         */
         HS_AppData.HkPacket.StatusFlags = 0;
-#if HS_MAX_EXEC_CNT_SLOTS != 0
         if (HS_AppData.ExeCountState == HS_STATE_ENABLED)
         {
             HS_AppData.HkPacket.StatusFlags |= HS_LOADED_XCT;
         }
-#endif
         if (HS_AppData.MsgActsState == HS_STATE_ENABLED)
         {
             HS_AppData.HkPacket.StatusFlags |= HS_LOADED_MAT;
@@ -232,7 +230,6 @@ void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
         HS_AppData.HkPacket.UtilCpuAvg  = HS_AppData.UtilCpuAvg;
         HS_AppData.HkPacket.UtilCpuPeak = HS_AppData.UtilCpuPeak;
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
         /*
         ** Add the execution counters
         */
@@ -281,8 +278,6 @@ void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
 
             HS_AppData.HkPacket.ExeCounts[TableIndex] = ExeCount;
         }
-
-#endif
 
         /*
         ** Timestamp and send housekeeping packet
@@ -789,7 +784,6 @@ void HS_AcquirePointers(void)
         HS_AppData.MsgActsState = HS_STATE_ENABLED;
     }
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     /*
     ** Release the table (ExeCount)
     */
@@ -827,8 +821,6 @@ void HS_AcquirePointers(void)
     {
         HS_AppData.ExeCountState = HS_STATE_ENABLED;
     }
-
-#endif
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -637,11 +637,10 @@ int32 HS_ValidateXCTable(void *TableData)
     HS_XCTEntry_t *TableArray = (HS_XCTEntry_t *)TableData;
 
     int32  TableResult = CFE_SUCCESS;
-    uint32 TableIndex  = 0;
-    int32  EntryResult = 0;
-
-    uint16 ResourceType = 0;
-    uint32 NullTerm     = 0;
+    uint32 TableIndex;
+    int32  EntryResult;
+    uint16 ResourceType;
+    uint32 NullTerm;
 
     uint32 GoodCount                = 0;
     uint32 BadCount                 = 0;

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -627,7 +627,6 @@ int32 HS_ValidateEMTable(void *TableData)
     return TableResult;
 }
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* Validate the Execution Counters Table                           */
@@ -718,7 +717,6 @@ int32 HS_ValidateXCTable(void *TableData)
 
     return TableResult;
 }
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/hs_verify.h
+++ b/fsw/src/hs_verify.h
@@ -41,8 +41,8 @@
 /*
  * Maximum number execution counters
  */
-#if HS_MAX_EXEC_CNT_SLOTS < 0
-#error HS_MAX_MSG_ACT_TYPES cannot be less than 0
+#if HS_MAX_EXEC_CNT_SLOTS < 1
+#error HS_MAX_MSG_ACT_TYPES cannot be less than 1
 #elif HS_MAX_EXEC_CNT_SLOTS > 4294967295
 #error HS_MAX_MSG_ACT_TYPES can not exceed 4294967295
 #endif

--- a/unit-test/hs_app_tests.c
+++ b/unit-test/hs_app_tests.c
@@ -1516,7 +1516,6 @@ void HS_TblInit_Test_RegisterMsgActsTableError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_TblInit_Test_RegisterExeCountTableError(void)
 {
     int32 Result;
@@ -1549,9 +1548,7 @@ void HS_TblInit_Test_RegisterExeCountTableError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_TblInit_Test_LoadExeCountTableError(void)
 {
     int32 Result;
@@ -1583,7 +1580,6 @@ void HS_TblInit_Test_LoadExeCountTableError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 6, "CFE_EVS_SendEvent was called %u time(s), expected 6",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
 void HS_TblInit_Test_LoadAppMonTableError(void)
 {
@@ -2003,7 +1999,6 @@ void HS_ProcessCommands_Test_NullMsgPtr(void)
  */
 void UtTest_Setup(void)
 {
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     UtTest_Add(HS_AppMain_Test_NominalWaitForStartupSync, HS_Test_Setup, HS_Test_TearDown,
                "HS_AppMain_Test_NominalWaitForStartupSync");
     UtTest_Add(HS_AppMain_Test_NominalRcvMsgSuccess, HS_Test_Setup, HS_Test_TearDown,
@@ -2023,10 +2018,8 @@ void UtTest_Setup(void)
                "HS_AppMain_Test_SBSubscribeEVSShortError");
     UtTest_Add(HS_AppMain_Test_RcvMsgError, HS_Test_Setup, HS_Test_TearDown, "HS_AppMain_Test_RcvMsgError");
     UtTest_Add(HS_AppMain_Test_StateDisabled, HS_Test_Setup, HS_Test_TearDown, "HS_AppMain_Test_StateDisabled");
-#endif
 
     UtTest_Add(HS_AppInit_Test_EVSRegisterError, HS_Test_Setup, HS_Test_TearDown, "HS_AppInit_Test_EVSRegisterError");
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     UtTest_Add(HS_AppInit_Test_Nominal, HS_Test_Setup, HS_Test_TearDown, "HS_AppInit_Test_Nominal");
     UtTest_Add(HS_AppInit_Test_CorruptCDSResetsPerformed, HS_Test_Setup, HS_Test_TearDown,
                "HS_AppInit_Test_CorruptCDSResetsPerformed");
@@ -2039,7 +2032,6 @@ void UtTest_Setup(void)
     UtTest_Add(HS_AppInit_Test_SBInitError, HS_Test_Setup, HS_Test_TearDown, "HS_AppInit_Test_SBInitError");
     UtTest_Add(HS_AppInit_Test_TblInitError, HS_Test_Setup, HS_Test_TearDown, "HS_AppInit_Test_TblInitError");
     UtTest_Add(HS_AppInit_Test_CustomInitError, HS_Test_Setup, HS_Test_TearDown, "HS_AppInit_Test_CustomInitError");
-#endif
 
     UtTest_Add(HS_SbInit_Test_Nominal, HS_Test_Setup, HS_Test_TearDown, "HS_SbInit_Test_Nominal");
     UtTest_Add(HS_SbInit_Test_CreateSBCmdPipeError, HS_Test_Setup, HS_Test_TearDown,
@@ -2054,7 +2046,6 @@ void UtTest_Setup(void)
     UtTest_Add(HS_SbInit_Test_SubscribeWakeupError, HS_Test_Setup, HS_Test_TearDown,
                "HS_SbInit_Test_SubscribeWakeupError");
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     UtTest_Add(HS_TblInit_Test_Nominal, HS_Test_Setup, HS_Test_TearDown, "HS_TblInit_Test_Nominal");
     UtTest_Add(HS_TblInit_Test_RegisterAppMonTableError, HS_Test_Setup, HS_Test_TearDown,
                "HS_TblInit_Test_RegisterAppMonTableError");
@@ -2072,7 +2063,6 @@ void UtTest_Setup(void)
                "HS_TblInit_Test_LoadEventMonTableError");
     UtTest_Add(HS_TblInit_Test_LoadMsgActsTableError, HS_Test_Setup, HS_Test_TearDown,
                "HS_TblInit_Test_LoadMsgActsTableError");
-#endif
 
     UtTest_Add(HS_ProcessMain_Test, HS_Test_Setup, HS_Test_TearDown, "HS_ProcessMain_Test");
     UtTest_Add(HS_ProcessMain_Test_MonStateDisabled, HS_Test_Setup, HS_Test_TearDown,

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -609,7 +609,6 @@ void HS_HousekeepingReq_Test_InvalidMsgLength(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -702,9 +701,7 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -802,9 +799,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -901,9 +896,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1002,9 +995,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1099,9 +1090,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1197,9 +1186,7 @@ void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeISR(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1288,9 +1275,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1382,9 +1367,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1478,7 +1461,6 @@ void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 32, "CFE_EVS_SendEvent was called %u time(s), expected 32",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
 void HS_Noop_Test(void)
 {
@@ -2641,7 +2623,6 @@ void HS_SetMaxResetsCmd_Test_MsgLengthError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_AcquirePointers_Test_Nominal(void)
 {
     HS_AMTEntry_t AMTable[HS_MAX_MONITORED_APPS];
@@ -2668,9 +2649,7 @@ void HS_AcquirePointers_Test_Nominal(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_AcquirePointers_Test_ErrorsWithAppMonLoadedAndEventMonLoadedEnabled(void)
 {
     int32 strCmpResult;
@@ -2743,9 +2722,7 @@ void HS_AcquirePointers_Test_ErrorsWithAppMonLoadedAndEventMonLoadedEnabled(void
     UtAssert_True(call_count_CFE_EVS_SendEvent == 4, "CFE_EVS_SendEvent was called %u time(s), expected 4",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled2(void)
 {
     int32 strCmpResult;
@@ -2831,9 +2808,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled2(v
     UtAssert_True(call_count_CFE_EVS_SendEvent == 5, "CFE_EVS_SendEvent was called %u time(s), expected 5",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled(void)
 {
     int32 strCmpResult;
@@ -2919,9 +2894,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled(vo
     UtAssert_True(call_count_CFE_EVS_SendEvent == 5, "CFE_EVS_SendEvent was called %u time(s), expected 5",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoSubscribeError(void)
 {
     HS_AppData.AppMonLoaded         = HS_STATE_DISABLED;
@@ -2963,9 +2936,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoS
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoSubscribeError2(void)
 {
     HS_AppData.AppMonLoaded         = HS_STATE_DISABLED;
@@ -3007,9 +2978,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoS
     UtAssert_True(call_count_CFE_EVS_SendEvent == 3, "CFE_EVS_SendEvent was called %u time(s), expected 3",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppMonStateDisabled(void)
 {
     HS_AppData.AppMonLoaded         = HS_STATE_DISABLED;
@@ -3046,7 +3015,6 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppM
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
 void HS_AppMonStatusRefresh_Test_CycleCountZero(void)
 {
@@ -3250,7 +3218,6 @@ void UtTest_Setup(void)
     UtTest_Add(HS_HousekeepingReq_Test_InvalidMsgLength, HS_Test_Setup, HS_Test_TearDown,
                "HS_HousekeepingReq_Test_InvalidMsgLength");
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     UtTest_Add(HS_HousekeepingReq_Test_AllFlagsEnabled, HS_Test_Setup, HS_Test_TearDown,
                "HS_HousekeepingReq_Test_AllFlagsEnabled");
     UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeAppMain, HS_Test_Setup, HS_Test_TearDown,
@@ -3269,8 +3236,6 @@ void UtTest_Setup(void)
                "HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError");
     UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeUnknown, HS_Test_Setup, HS_Test_TearDown,
                "HS_HousekeepingReq_Test_ResourceTypeAppMain");
-
-#endif
 
     UtTest_Add(HS_Noop_Test, HS_Test_Setup, HS_Test_TearDown, "HS_Noop_Test");
     UtTest_Add(HS_Noop_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown, "HS_Noop_Test_MsgLengthError");
@@ -3335,7 +3300,6 @@ void UtTest_Setup(void)
     UtTest_Add(HS_SetMaxResetsCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
                "HS_SetMaxResetsCmd_Test_MsgLengthError");
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     UtTest_Add(HS_AcquirePointers_Test_Nominal, HS_Test_Setup, HS_Test_TearDown, "HS_AcquirePointers_Test_Nominal");
     UtTest_Add(HS_AcquirePointers_Test_ErrorsWithAppMonLoadedAndEventMonLoadedEnabled, HS_Test_Setup, HS_Test_TearDown,
                "HS_AcquirePointers_Test_ErrorsWithAppMonLoadedAndEventMonLoadedEnabled");
@@ -3349,7 +3313,6 @@ void UtTest_Setup(void)
     UtTest_Add(HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppMonStateDisabled,
                HS_Test_Setup, HS_Test_TearDown,
                "HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppMonStateDisabled");
-#endif
 
     UtTest_Add(HS_AppMonStatusRefresh_Test_CycleCountZero, HS_Test_Setup, HS_Test_TearDown,
                "HS_AppMonStatusRefresh_Test_CycleCountZero");

--- a/unit-test/hs_monitors_tests.c
+++ b/unit-test/hs_monitors_tests.c
@@ -2397,7 +2397,6 @@ void HS_ValidateEMTable_Test_Null(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_ValidateXCTable_Test_UnusedTableEntry(void)
 {
     int32         Result;
@@ -2437,9 +2436,7 @@ void HS_ValidateXCTable_Test_UnusedTableEntry(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_ValidateXCTable_Test_BufferNotNull(void)
 {
     int32         Result;
@@ -2491,9 +2488,7 @@ void HS_ValidateXCTable_Test_BufferNotNull(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_ValidateXCTable_Test_ResourceTypeNotValid(void)
 {
     int32         Result;
@@ -2551,9 +2546,7 @@ void HS_ValidateXCTable_Test_ResourceTypeNotValid(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_ValidateXCTable_Test_EntryGood(void)
 {
     int32         Result;
@@ -2593,9 +2586,7 @@ void HS_ValidateXCTable_Test_EntryGood(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
 void HS_ValidateXCTable_Test_Null(void)
 {
     int32 Result;
@@ -2623,7 +2614,6 @@ void HS_ValidateXCTable_Test_Null(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
 }
-#endif
 
 void HS_ValidateMATable_Test_UnusedTableEntry(void)
 {
@@ -3053,7 +3043,6 @@ void UtTest_Setup(void)
     UtTest_Add(HS_ValidateEMTable_Test_EntryGood, HS_Test_Setup, HS_Test_TearDown, "HS_ValidateEMTable_Test_EntryGood");
     UtTest_Add(HS_ValidateEMTable_Test_Null, HS_Test_Setup, HS_Test_TearDown, "HS_ValidateEMTable_Test_Null");
 
-#if HS_MAX_EXEC_CNT_SLOTS != 0
     UtTest_Add(HS_ValidateXCTable_Test_UnusedTableEntry, HS_Test_Setup, HS_Test_TearDown,
                "HS_ValidateXCTable_Test_UnusedTableEntry");
     UtTest_Add(HS_ValidateXCTable_Test_BufferNotNull, HS_Test_Setup, HS_Test_TearDown,
@@ -3062,7 +3051,6 @@ void UtTest_Setup(void)
                "HS_ValidateXCTable_Test_ResourceTypeNotValid");
     UtTest_Add(HS_ValidateXCTable_Test_EntryGood, HS_Test_Setup, HS_Test_TearDown, "HS_ValidateXCTable_Test_EntryGood");
     UtTest_Add(HS_ValidateXCTable_Test_Null, HS_Test_Setup, HS_Test_TearDown, "HS_ValidateXCTable_Test_Null");
-#endif
 
     UtTest_Add(HS_ValidateMATable_Test_UnusedTableEntry, HS_Test_Setup, HS_Test_TearDown,
                "HS_ValidateMATable_Test_UnusedTableEntry");


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Do not conditionally compile code based on HS_MAX_EXEC_CNT_SLOTS being 0.  It will now be required that the option is >0.  Note that a configuration of 0 was not being tested/validated, so this removes an untested option.

Fixes #69
Fixes #73

**Testing performed**
Build and run all tests.

**Expected behavior changes**
No change with default config (default value was 32, so all code was being compiled in normally).
Attempting to build HS with the value of 0 will result in a verify error now (min value is now 1, whereas it was 0 previously).

**System(s) tested on**
Debian

**Additional context**
Removes an untested configuration option.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

