### PR TITLE
Fix #71, check correct global in appmon UT

### DIFF
--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -3072,12 +3072,12 @@ void HS_AppMonStatusRefresh_Test_CycleCountZero(void)
 
     /* Verify results */
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0,
+    UtAssert_True(HS_AppData.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] == 0,
+    UtAssert_True(HS_AppData.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] == 0,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == 0");
 
     UtAssert_True(HS_AppData.AppMonLastExeCount[0] == 0, "HS_AppData.AppMonLastExeCount[0] == 0");
@@ -3120,12 +3120,12 @@ void HS_AppMonStatusRefresh_Test_ActionTypeNOACT(void)
 
     /* Verify results */
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0,
+    UtAssert_True(HS_AppData.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] == 0,
+    UtAssert_True(HS_AppData.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] == 0,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == 0");
 
     UtAssert_True(HS_AppData.AppMonLastExeCount[0] == 0, "HS_AppData.AppMonLastExeCount[0] == 0");


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The AppMon unit test was checking the array in the HK packet rather than the array in the global - which is the one that was updated in the Unit under test.

Fixes #71

**Testing performed**
Build and run all tests

**Expected behavior changes**
Affects UT only, no change to FSW

**System(s) tested on**
Ubuntu

**Additional context**
It appears these checks in the UT might be inconsequential anyway because they are all zero, and nothing sets it nonzero.  This is why they were passing even though it was "verifying" the wrong thing (i.e. the wrong thing was also 0).  Fixing that is left to a future exercise, if desired.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
