### PR TITLE
Fix #9, use CFE_MSG_PTR macro

### DIFF
--- a/fsw/inc/hs_custom.h
+++ b/fsw/inc/hs_custom.h
@@ -36,6 +36,16 @@
 #define HS_UTIL_DIAG_REPORTS 4
 
 /**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_REPORT_DIAG_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_ReportDiagCmd_t;
+
+/**
  * \ingroup cfshscmdcodes
  *
  * Custom command codes must not conflict with those in hs_msgdefs.h
@@ -49,7 +59,7 @@
  *       Reports the Utilization Diagnostics
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_ReportDiagCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with

--- a/fsw/inc/hs_msg.h
+++ b/fsw/inc/hs_msg.h
@@ -54,15 +54,112 @@
 /**
  *  \brief No Arguments Command
  *
- *  For command details see #HS_NOOP_CC, #HS_RESET_CC, #HS_ENABLE_APPMON_CC, #HS_DISABLE_APPMON_CC,
- *  #HS_ENABLE_EVENTMON_CC, #HS_DISABLE_EVENTMON_CC, #HS_ENABLE_ALIVENESS_CC, #HS_DISABLE_ALIVENESS_CC,
- *  #HS_RESET_RESETS_PERFORMED_CC
- *  Also see #HS_SEND_HK_MID
+ *  For command details see #HS_NOOP_CC
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
-} HS_NoArgsCmd_t;
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_NoopCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_RESET_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_ResetCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_ENABLE_APPMON_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_EnableAppMonCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_DISABLE_APPMON_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_DisableAppMonCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_ENABLE_EVENTMON_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_EnableEventMonCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_DISABLE_EVENTMON_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_DisableEventMonCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_ENABLE_ALIVENESS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_EnableAlivenessCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_DISABLE_ALIVENESS_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_DisableAlivenessCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_RESET_RESETS_PERFORMED_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_ResetResetsPerformedCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_RESET_RESETS_PERFORMED_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_EnableCpuHogCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_RESET_RESETS_PERFORMED_CC
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_DisableCpuHogCmd_t;
 
 /**
  *  \brief Set Max Resets Command
@@ -71,11 +168,21 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
     uint16 MaxResets; /**< \brief Maximum Resets */
     uint16 Padding;   /**< \brief Structure padding */
 } HS_SetMaxResetsCmd_t;
+
+/**
+ *  \brief No Arguments Command
+ *
+ *  For command details see #HS_SEND_HK_MID
+ */
+typedef struct
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} HS_SendHkCmd_t;
 
 /**\}*/
 
@@ -89,7 +196,7 @@ typedef struct
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief Telemetry Header */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
 
     uint8  CmdCount;              /**< \brief HS Application Command Counter */
     uint8  CmdErrCount;           /**< \brief HS Application Command Error Counter */

--- a/fsw/inc/hs_msg.h
+++ b/fsw/inc/hs_msg.h
@@ -74,7 +74,7 @@ typedef struct
 /**
  *  \brief No Arguments Command
  *
- *  For command details see #HS_ENABLE_APPMON_CC
+ *  For command details see #HS_ENABLE_APP_MON_CC
  */
 typedef struct
 {
@@ -84,7 +84,7 @@ typedef struct
 /**
  *  \brief No Arguments Command
  *
- *  For command details see #HS_DISABLE_APPMON_CC
+ *  For command details see #HS_DISABLE_APP_MON_CC
  */
 typedef struct
 {
@@ -94,7 +94,7 @@ typedef struct
 /**
  *  \brief No Arguments Command
  *
- *  For command details see #HS_ENABLE_EVENTMON_CC
+ *  For command details see #HS_ENABLE_EVENT_MON_CC
  */
 typedef struct
 {
@@ -104,7 +104,7 @@ typedef struct
 /**
  *  \brief No Arguments Command
  *
- *  For command details see #HS_DISABLE_EVENTMON_CC
+ *  For command details see #HS_DISABLE_EVENT_MON_CC
  */
 typedef struct
 {

--- a/fsw/inc/hs_msgdefs.h
+++ b/fsw/inc/hs_msgdefs.h
@@ -73,7 +73,7 @@
  *       Implements the Noop command that insures the HS task is alive
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_NoopCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -104,7 +104,7 @@
  *       Resets the HS housekeeping counters
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_ResetCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -135,7 +135,7 @@
  *       Enables the Applications Monitor
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_EnableAppMonCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -156,9 +156,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #HS_DISABLE_APPMON_CC
+ *  \sa #HS_DISABLE_APP_MON_CC
  */
-#define HS_ENABLE_APPMON_CC 2
+#define HS_ENABLE_APP_MON_CC 2
 
 /**
  * \brief Disable Applications Monitor
@@ -167,7 +167,7 @@
  *       Disables the Applications Monitor
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_DisableAppMonCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -188,9 +188,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #HS_ENABLE_APPMON_CC
+ *  \sa #HS_ENABLE_APP_MON_CC
  */
-#define HS_DISABLE_APPMON_CC 3
+#define HS_DISABLE_APP_MON_CC 3
 
 /**
  * \brief Enable Events Monitor
@@ -199,7 +199,7 @@
  *       Enables the Events Monitor
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_EnableEventMonCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -220,9 +220,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #HS_DISABLE_EVENTMON_CC
+ *  \sa #HS_DISABLE_EVENT_MON_CC
  */
-#define HS_ENABLE_EVENTMON_CC 4
+#define HS_ENABLE_EVENT_MON_CC 4
 
 /**
  * \brief Disable Events Monitor
@@ -231,7 +231,7 @@
  *       Disables the Events Monitor
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_DisableEventMonCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -252,9 +252,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #HS_ENABLE_EVENTMON_CC
+ *  \sa #HS_ENABLE_EVENT_MON_CC
  */
-#define HS_DISABLE_EVENTMON_CC 5
+#define HS_DISABLE_EVENT_MON_CC 5
 
 /**
  * \brief Enable Aliveness Indicator
@@ -263,7 +263,7 @@
  *       Enables the Aliveness Indicator UART output
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_EnableAlivenessCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -295,7 +295,7 @@
  *       Disables the Aliveness Indicator UART output
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_DisableAlivenessCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -327,7 +327,7 @@
  *       Resets the count of HS performed resets maintained by HS
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_ResetResetsPerformedCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -391,7 +391,7 @@
  *       Enables the CPU Hogging Indicator Event Message
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_EnableCpuHogCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -412,9 +412,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #HS_DISABLE_CPUHOG_CC
+ *  \sa #HS_DISABLE_CPU_HOG_CC
  */
-#define HS_ENABLE_CPUHOG_CC 10
+#define HS_ENABLE_CPU_HOG_CC 10
 
 /**
  * \brief Disable CPU Hogging Indicator
@@ -423,7 +423,7 @@
  *       Disables the CPU Hogging Indicator Event Message
  *
  *  \par Command Structure
- *       #HS_NoArgsCmd_t
+ *       #HS_DisableCpuHogCmd_t
  *
  *  \par Command Verification
  *       Successful execution of this command may be verified with
@@ -444,9 +444,9 @@
  *  \par Criticality
  *       None
  *
- *  \sa #HS_ENABLE_CPUHOG_CC
+ *  \sa #HS_ENABLE_CPU_HOG_CC
  */
-#define HS_DISABLE_CPUHOG_CC 11
+#define HS_DISABLE_CPU_HOG_CC 11
 
 /**\}*/
 

--- a/fsw/src/hs_app.c
+++ b/fsw/src/hs_app.c
@@ -350,7 +350,8 @@ int32 HS_SbInit(void)
     int32 Status;
 
     /* Initialize housekeeping packet  */
-    CFE_MSG_Init(&HS_AppData.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(HS_HK_TLM_MID), sizeof(HS_HkPacket_t));
+    CFE_MSG_Init(CFE_MSG_PTR(HS_AppData.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(HS_HK_TLM_MID),
+                 sizeof(HS_HkPacket_t));
 
     /* Create Command Pipe */
     Status = CFE_SB_CreatePipe(&HS_AppData.CmdPipe, HS_CMD_PIPE_DEPTH, HS_CMD_PIPE_NAME);

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -105,11 +105,11 @@ void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
                     break;
 
                 case HS_ENABLE_CPUHOG_CC:
-                    HS_EnableCPUHogCmd(BufPtr);
+                    HS_EnableCpuHogCmd(BufPtr);
                     break;
 
                 case HS_DISABLE_CPUHOG_CC:
-                    HS_DisableCPUHogCmd(BufPtr);
+                    HS_DisableCpuHogCmd(BufPtr);
                     break;
 
                 default:
@@ -145,7 +145,7 @@ void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t         ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t         ExpectedLength = sizeof(HS_SendHkCmd_t);
     CFE_ES_AppId_t AppId          = CFE_ES_APPID_UNDEFINED;
 #if HS_MAX_EXEC_CNT_SLOTS != 0
     uint32             ExeCount  = 0;
@@ -287,8 +287,8 @@ void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
         /*
         ** Timestamp and send housekeeping packet
         */
-        CFE_SB_TimeStampMsg(&HS_AppData.HkPacket.TlmHeader.Msg);
-        CFE_SB_TransmitMsg(&HS_AppData.HkPacket.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(HS_AppData.HkPacket.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(HS_AppData.HkPacket.TelemetryHeader), true);
 
     } /* end HS_VerifyMsgLength if */
 }
@@ -300,7 +300,7 @@ void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_NoopCmd_t);
 
     /*
     ** Verify message packet length
@@ -321,7 +321,7 @@ void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_ResetCmd_t);
 
     /*
     ** Verify message packet length
@@ -354,7 +354,7 @@ void HS_ResetCounters(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_EnableAppMonCmd_t);
 
     /*
     ** Verify message packet length
@@ -375,7 +375,7 @@ void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_DisableAppMonCmd_t);
 
     /*
     ** Verify message packet length
@@ -395,7 +395,7 @@ void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_EnableEventMonCmd_t);
     int32  Status         = CFE_SUCCESS;
 
     /*
@@ -452,7 +452,7 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_DisableEventMonCmd_t);
     int32  Status         = CFE_SUCCESS;
 
     /*
@@ -507,7 +507,7 @@ void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_EnableAlivenessCmd_t);
 
     /*
     ** Verify message packet length
@@ -527,7 +527,7 @@ void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_DisableAlivenessCmd_t);
 
     /*
     ** Verify message packet length
@@ -545,9 +545,9 @@ void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Enable cpu hogging indicator command                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_EnableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr)
+void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_EnableCpuHogCmd_t);
 
     /*
     ** Verify message packet length
@@ -565,9 +565,9 @@ void HS_EnableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Disable cpu hogging indicator command                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_DisableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr)
+void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_DisableCpuHogCmd_t);
 
     /*
     ** Verify message packet length
@@ -587,7 +587,7 @@ void HS_DisableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    size_t ExpectedLength = sizeof(HS_NoArgsCmd_t);
+    size_t ExpectedLength = sizeof(HS_ResetResetsPerformedCmd_t);
 
     /*
     ** Verify message packet length

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -72,19 +72,19 @@ void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
                     HS_ResetCmd(BufPtr);
                     break;
 
-                case HS_ENABLE_APPMON_CC:
+                case HS_ENABLE_APP_MON_CC:
                     HS_EnableAppMonCmd(BufPtr);
                     break;
 
-                case HS_DISABLE_APPMON_CC:
+                case HS_DISABLE_APP_MON_CC:
                     HS_DisableAppMonCmd(BufPtr);
                     break;
 
-                case HS_ENABLE_EVENTMON_CC:
+                case HS_ENABLE_EVENT_MON_CC:
                     HS_EnableEventMonCmd(BufPtr);
                     break;
 
-                case HS_DISABLE_EVENTMON_CC:
+                case HS_DISABLE_EVENT_MON_CC:
                     HS_DisableEventMonCmd(BufPtr);
                     break;
 
@@ -104,11 +104,11 @@ void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
                     HS_SetMaxResetsCmd(BufPtr);
                     break;
 
-                case HS_ENABLE_CPUHOG_CC:
+                case HS_ENABLE_CPU_HOG_CC:
                     HS_EnableCpuHogCmd(BufPtr);
                     break;
 
-                case HS_DISABLE_CPUHOG_CC:
+                case HS_DISABLE_CPU_HOG_CC:
                     HS_DisableCpuHogCmd(BufPtr);
                     break;
 

--- a/fsw/src/hs_cmds.h
+++ b/fsw/src/hs_cmds.h
@@ -227,7 +227,7 @@ void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_ENABLE_CPUHOG_CC
  */
-void HS_EnableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr);
+void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Process a disable CPU Hogging indicator command
@@ -242,7 +242,7 @@ void HS_EnableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_DISABLE_CPUHOG_CC
  */
-void HS_DisableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr);
+void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Process a reset resets performed command

--- a/fsw/src/hs_cmds.h
+++ b/fsw/src/hs_cmds.h
@@ -135,7 +135,7 @@ void HS_ResetCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \sa #HS_ENABLE_APPMON_CC
+ *  \sa #HS_ENABLE_APP_MON_CC
  */
 void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -150,7 +150,7 @@ void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \sa #HS_DISABLE_APPMON_CC
+ *  \sa #HS_DISABLE_APP_MON_CC
  */
 void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -165,7 +165,7 @@ void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \sa #HS_ENABLE_EVENTMON_CC
+ *  \sa #HS_ENABLE_EVENT_MON_CC
  */
 void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -180,7 +180,7 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \sa #HS_DISABLE_EVENTMON_CC
+ *  \sa #HS_DISABLE_EVENT_MON_CC
  */
 void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -225,7 +225,7 @@ void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \sa #HS_ENABLE_CPUHOG_CC
+ *  \sa #HS_ENABLE_CPU_HOG_CC
  */
 void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
 
@@ -240,7 +240,7 @@ void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \sa #HS_DISABLE_CPUHOG_CC
+ *  \sa #HS_DISABLE_CPU_HOG_CC
  */
 void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
 

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -50,7 +50,6 @@ void HS_MonitorApplications(void)
     uint32           TableIndex = 0;
     uint16           ActionType;
     uint32           MsgActsIndex = 0;
-    CFE_SB_Buffer_t *BufPtr       = NULL;
 
     memset(&AppInfo, 0, sizeof(AppInfo));
 
@@ -188,8 +187,8 @@ void HS_MonitorApplications(void)
                                 if ((HS_AppData.MsgActCooldown[MsgActsIndex] == 0) &&
                                     (HS_AppData.MATablePtr[MsgActsIndex].EnableState != HS_MAT_STATE_DISABLED))
                                 {
-                                    BufPtr = (CFE_SB_Buffer_t *)&HS_AppData.MATablePtr[MsgActsIndex].MsgBuf;
-                                    CFE_SB_TransmitMsg(&BufPtr->Msg, true);
+                                    CFE_SB_TransmitMsg(
+                                        (const CFE_MSG_Message_t *)&HS_AppData.MATablePtr[MsgActsIndex].MsgBuf, true);
                                     HS_AppData.MsgActExec++;
                                     HS_AppData.MsgActCooldown[MsgActsIndex] =
                                         HS_AppData.MATablePtr[MsgActsIndex].Cooldown;

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -65,7 +65,7 @@ void HS_AppPipe_Test_SendHK(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_SEND_HK_MID);
     FcnCode   = 0;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.SendHkCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -90,7 +90,7 @@ void HS_AppPipe_Test_Noop(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_NOOP_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.NoopCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -117,7 +117,7 @@ void HS_AppPipe_Test_Reset(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_RESET_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.ResetCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -148,7 +148,7 @@ void HS_AppPipe_Test_EnableAppMon(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_APPMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -177,7 +177,7 @@ void HS_AppPipe_Test_DisableAppMon(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_APPMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -206,7 +206,7 @@ void HS_AppPipe_Test_EnableEventMon(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -235,7 +235,7 @@ void HS_AppPipe_Test_DisableEventMon(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -261,7 +261,7 @@ void HS_AppPipe_Test_EnableAliveness(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableAlivenessCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -287,7 +287,7 @@ void HS_AppPipe_Test_DisableAliveness(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableAlivenessCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -313,7 +313,7 @@ void HS_AppPipe_Test_ResetResetsPerformed(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_RESET_RESETS_PERFORMED_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.ResetResetsPerformedCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -339,7 +339,7 @@ void HS_AppPipe_Test_SetMaxResets(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_MAX_RESETS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.SetMaxResetsCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -365,7 +365,7 @@ void HS_AppPipe_Test_EnableCPUHog(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_CPUHOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -391,7 +391,7 @@ void HS_AppPipe_Test_DisableCPUHog(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_CPUHOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -421,7 +421,7 @@ void HS_AppPipe_Test_InvalidCC(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = 99;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -459,7 +459,7 @@ void HS_AppPipe_Test_InvalidCCNoEvent(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = 99;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -489,7 +489,7 @@ void HS_AppPipe_Test_InvalidMID(void)
 
     TestMsgId = CFE_SB_INVALID_MSG_ID;
     FcnCode   = HS_NOOP_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -530,7 +530,7 @@ void HS_HousekeepingReq_Test_InvalidEventMon(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -633,7 +633,7 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -730,7 +730,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -829,7 +829,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -928,7 +928,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1028,7 +1028,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1126,7 +1126,7 @@ void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1223,7 +1223,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1314,7 +1314,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1409,7 +1409,7 @@ void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1491,7 +1491,7 @@ void HS_Noop_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_NOOP_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.NoopCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1526,7 +1526,7 @@ void HS_Noop_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_NOOP_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.NoopCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1556,7 +1556,7 @@ void HS_ResetCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_RESET_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.ResetCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1591,7 +1591,7 @@ void HS_ResetCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_RESET_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.ResetCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1645,7 +1645,7 @@ void HS_EnableAppMonCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_APPMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1686,7 +1686,7 @@ void HS_EnableAppMonCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_APPMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1723,7 +1723,7 @@ void HS_DisableAppMonCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_APPMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1761,7 +1761,7 @@ void HS_DisableAppMonCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_APPMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1796,7 +1796,7 @@ void HS_EnableEventMonCmd_Test_Disabled(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1836,7 +1836,7 @@ void HS_EnableEventMonCmd_Test_DisabledMsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1871,7 +1871,7 @@ void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1915,7 +1915,7 @@ void HS_EnableEventMonCmd_Test_SubscribeLongError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -1961,7 +1961,7 @@ void HS_EnableEventMonCmd_Test_SubscribeShortError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2006,7 +2006,7 @@ void HS_DisableEventMonCmd_Test_Enabled(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2049,7 +2049,7 @@ void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2093,7 +2093,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeLongError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2139,7 +2139,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeShortError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2181,7 +2181,7 @@ void HS_DisableEventMonCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_EVENTMON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2216,7 +2216,7 @@ void HS_EnableAlivenessCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableAlivenessCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2256,7 +2256,7 @@ void HS_EnableAlivenessCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableAlivenessCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2291,7 +2291,7 @@ void HS_DisableAlivenessCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableAlivenessCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2331,7 +2331,7 @@ void HS_DisableAlivenessCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableAlivenessCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2355,7 +2355,7 @@ void HS_DisableAlivenessCmd_Test_MsgLengthError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_EnableCPUHogCmd_Test(void)
+void HS_EnableCpuHogCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2366,7 +2366,7 @@ void HS_EnableCPUHogCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_CPUHOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2377,7 +2377,7 @@ void HS_EnableCPUHogCmd_Test(void)
     HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
 
     /* Execute the function being tested */
-    HS_EnableCPUHogCmd(&UT_CmdBuf.Buf);
+    HS_EnableCpuHogCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -2398,7 +2398,7 @@ void HS_EnableCPUHogCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_EnableCPUHogCmd_Test_MsgLengthError(void)
+void HS_EnableCpuHogCmd_Test_MsgLengthError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2406,7 +2406,7 @@ void HS_EnableCPUHogCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_CPUHOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2417,7 +2417,7 @@ void HS_EnableCPUHogCmd_Test_MsgLengthError(void)
     HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
 
     /* Execute the function being tested */
-    HS_EnableCPUHogCmd(&UT_CmdBuf.Buf);
+    HS_EnableCpuHogCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
@@ -2430,7 +2430,7 @@ void HS_EnableCPUHogCmd_Test_MsgLengthError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_DisableCPUHogCmd_Test(void)
+void HS_DisableCpuHogCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2441,7 +2441,7 @@ void HS_DisableCPUHogCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_CPUHOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2452,7 +2452,7 @@ void HS_DisableCPUHogCmd_Test(void)
     HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
 
     /* Execute the function being tested */
-    HS_DisableCPUHogCmd(&UT_CmdBuf.Buf);
+    HS_DisableCpuHogCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -2473,7 +2473,7 @@ void HS_DisableCPUHogCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_DisableCPUHogCmd_Test_MsgLengthError(void)
+void HS_DisableCpuHogCmd_Test_MsgLengthError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2481,7 +2481,7 @@ void HS_DisableCPUHogCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_CPUHOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2492,7 +2492,7 @@ void HS_DisableCPUHogCmd_Test_MsgLengthError(void)
     HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
 
     /* Execute the function being tested */
-    HS_DisableCPUHogCmd(&UT_CmdBuf.Buf);
+    HS_DisableCpuHogCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
@@ -2517,7 +2517,7 @@ void HS_ResetResetsPerformedCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_RESET_RESETS_PERFORMED_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.ResetResetsPerformedCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -2552,7 +2552,7 @@ void HS_ResetResetsPerformedCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_RESET_RESETS_PERFORMED_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.ResetResetsPerformedCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -3319,13 +3319,13 @@ void UtTest_Setup(void)
     UtTest_Add(HS_DisableAlivenessCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
                "HS_DisableAlivenessCmd_Test_MsgLengthError");
 
-    UtTest_Add(HS_EnableCPUHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableCPUHogCmd_Test");
-    UtTest_Add(HS_EnableCPUHogCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_EnableCPUHogCmd_Test_MsgLengthError");
+    UtTest_Add(HS_EnableCpuHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableCpuHogCmd_Test");
+    UtTest_Add(HS_EnableCpuHogCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
+               "HS_EnableCpuHogCmd_Test_MsgLengthError");
 
-    UtTest_Add(HS_DisableCPUHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableCPUHogCmd_Test");
-    UtTest_Add(HS_DisableCPUHogCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_DisableCPUHogCmd_Test_MsgLengthError");
+    UtTest_Add(HS_DisableCpuHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableCpuHogCmd_Test");
+    UtTest_Add(HS_DisableCpuHogCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
+               "HS_DisableCpuHogCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_ResetResetsPerformedCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_ResetResetsPerformedCmd_Test");
     UtTest_Add(HS_ResetResetsPerformedCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -147,7 +147,7 @@ void HS_AppPipe_Test_EnableAppMon(void)
     HS_AppData.AMTablePtr = AMTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_APPMON_CC;
+    FcnCode   = HS_ENABLE_APP_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -176,7 +176,7 @@ void HS_AppPipe_Test_DisableAppMon(void)
     HS_AppData.AMTablePtr = AMTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_APPMON_CC;
+    FcnCode   = HS_DISABLE_APP_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -205,7 +205,7 @@ void HS_AppPipe_Test_EnableEventMon(void)
     HS_AppData.EMTablePtr = EMTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -234,7 +234,7 @@ void HS_AppPipe_Test_DisableEventMon(void)
     HS_AppData.EMTablePtr = EMTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENTMON_CC;
+    FcnCode   = HS_DISABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -364,7 +364,7 @@ void HS_AppPipe_Test_EnableCPUHog(void)
     size_t            MsgSize;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_CPUHOG_CC;
+    FcnCode   = HS_ENABLE_CPU_HOG_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -390,7 +390,7 @@ void HS_AppPipe_Test_DisableCPUHog(void)
     size_t            MsgSize;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_CPUHOG_CC;
+    FcnCode   = HS_DISABLE_CPU_HOG_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -529,7 +529,7 @@ void HS_HousekeepingReq_Test_InvalidEventMon(void)
     HS_AppData.EMTablePtr = EMTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -632,7 +632,7 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -729,7 +729,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -828,7 +828,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -927,7 +927,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1027,7 +1027,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1125,7 +1125,7 @@ void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1222,7 +1222,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1313,7 +1313,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1408,7 +1408,7 @@ void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
     HS_AppData.XCTablePtr = XCTable;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1644,7 +1644,7 @@ void HS_EnableAppMonCmd_Test(void)
     memset(AMTable, 0, sizeof(AMTable));
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_APPMON_CC;
+    FcnCode   = HS_ENABLE_APP_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1685,7 +1685,7 @@ void HS_EnableAppMonCmd_Test_MsgLengthError(void)
     HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_APPMON_CC;
+    FcnCode   = HS_ENABLE_APP_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1722,7 +1722,7 @@ void HS_DisableAppMonCmd_Test(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Application Monitoring Disabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_APPMON_CC;
+    FcnCode   = HS_DISABLE_APP_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1760,7 +1760,7 @@ void HS_DisableAppMonCmd_Test_MsgLengthError(void)
     size_t            MsgSize;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_APPMON_CC;
+    FcnCode   = HS_DISABLE_APP_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1795,7 +1795,7 @@ void HS_EnableEventMonCmd_Test_Disabled(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring Enabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1835,7 +1835,7 @@ void HS_EnableEventMonCmd_Test_DisabledMsgLengthError(void)
     size_t            MsgSize;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1870,7 +1870,7 @@ void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring Enabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1914,7 +1914,7 @@ void HS_EnableEventMonCmd_Test_SubscribeLongError(void)
              "Event Monitor Enable: Error Subscribing to long-format Events,RC=0x%%08X");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -1960,7 +1960,7 @@ void HS_EnableEventMonCmd_Test_SubscribeShortError(void)
              "Event Monitor Enable: Error Subscribing to short-format Events,RC=0x%%08X");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENTMON_CC;
+    FcnCode   = HS_ENABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2005,7 +2005,7 @@ void HS_DisableEventMonCmd_Test_Enabled(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring Disabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENTMON_CC;
+    FcnCode   = HS_DISABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2048,7 +2048,7 @@ void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring Disabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENTMON_CC;
+    FcnCode   = HS_DISABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2092,7 +2092,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeLongError(void)
              "Event Monitor Disable: Error Unsubscribing from long-format Events,RC=0x%%08X");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENTMON_CC;
+    FcnCode   = HS_DISABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2138,7 +2138,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeShortError(void)
              "Event Monitor Disable: Error Unsubscribing from short-format Events,RC=0x%%08X");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENTMON_CC;
+    FcnCode   = HS_DISABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2180,7 +2180,7 @@ void HS_DisableEventMonCmd_Test_MsgLengthError(void)
     size_t            MsgSize;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENTMON_CC;
+    FcnCode   = HS_DISABLE_EVENT_MON_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2365,7 +2365,7 @@ void HS_EnableCpuHogCmd_Test(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CPU Hogging Indicator Enabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_CPUHOG_CC;
+    FcnCode   = HS_ENABLE_CPU_HOG_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2405,7 +2405,7 @@ void HS_EnableCpuHogCmd_Test_MsgLengthError(void)
     size_t            MsgSize;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_CPUHOG_CC;
+    FcnCode   = HS_ENABLE_CPU_HOG_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2440,7 +2440,7 @@ void HS_DisableCpuHogCmd_Test(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CPU Hogging Indicator Disabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_CPUHOG_CC;
+    FcnCode   = HS_DISABLE_CPU_HOG_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
@@ -2480,7 +2480,7 @@ void HS_DisableCpuHogCmd_Test_MsgLengthError(void)
     size_t            MsgSize;
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_CPUHOG_CC;
+    FcnCode   = HS_DISABLE_CPU_HOG_CC;
     MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);

--- a/unit-test/hs_custom_tests.c
+++ b/unit-test/hs_custom_tests.c
@@ -37,6 +37,16 @@
 /* hs_custom_tests globals */
 uint8 call_count_CFE_EVS_SendEvent;
 
+/* Command buffer typedef for any handler */
+typedef union
+{
+    CFE_SB_Buffer_t       Buf;
+    HS_SetUtilParamsCmd_t SetUtilParamsCmd;
+    HS_SetUtilDiagCmd_t   SetUtilDiagCmd;
+} UT_CustomCmdBuf_t;
+
+UT_CustomCmdBuf_t UT_CustomCmdBuf;
+
 /*
  * Function Definitions
  */
@@ -271,7 +281,7 @@ void HS_CustomCommands_Test_UtilDiagReport(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_REPORT_DIAG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -280,7 +290,7 @@ void HS_CustomCommands_Test_UtilDiagReport(void)
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CmdBuf.Buf);
+    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
@@ -300,7 +310,7 @@ void HS_CustomCommands_Test_SetUtilParamsCmd(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilParamsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -309,7 +319,7 @@ void HS_CustomCommands_Test_SetUtilParamsCmd(void)
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CmdBuf.Buf);
+    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
@@ -329,7 +339,7 @@ void HS_CustomCommands_Test_SetUtilDiagCmd(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_DIAG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilDiagCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilDiagCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -338,7 +348,7 @@ void HS_CustomCommands_Test_SetUtilDiagCmd(void)
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CmdBuf.Buf);
+    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
@@ -358,13 +368,13 @@ void HS_CustomCommands_Test_InvalidCommandCode(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = 99;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CmdBuf.Buf);
+    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(Result == !CFE_SUCCESS, "Result == !CFE_SUCCESS");
@@ -498,7 +508,7 @@ void HS_SetUtilParamsCmd_Test_Nominal(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilParamsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -506,12 +516,12 @@ void HS_SetUtilParamsCmd_Test_Nominal(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
-    UT_CmdBuf.SetUtilParamsCmd.Mult1 = 1;
-    UT_CmdBuf.SetUtilParamsCmd.Mult2 = 2;
-    UT_CmdBuf.SetUtilParamsCmd.Div   = 3;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 3;
 
     /* Execute the function being tested */
-    HS_SetUtilParamsCmd(&UT_CmdBuf.Buf);
+    HS_SetUtilParamsCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_CustomData.UtilMult1 == 1, "HS_CustomData.UtilMult1 == 1");
@@ -544,7 +554,7 @@ void HS_SetUtilParamsCmd_Test_NominalMultZero(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilParamsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -552,12 +562,12 @@ void HS_SetUtilParamsCmd_Test_NominalMultZero(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
-    UT_CmdBuf.SetUtilParamsCmd.Mult1 = 1;
-    UT_CmdBuf.SetUtilParamsCmd.Mult2 = 0;
-    UT_CmdBuf.SetUtilParamsCmd.Div   = 3;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 0;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 3;
 
     /* Execute the function being tested */
-    HS_SetUtilParamsCmd(&UT_CmdBuf.Buf);
+    HS_SetUtilParamsCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_INT32_EQ(HS_CustomData.UtilMult1, 0);
@@ -590,7 +600,7 @@ void HS_SetUtilParamsCmd_Test_NominalDivZero(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilParamsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -598,12 +608,12 @@ void HS_SetUtilParamsCmd_Test_NominalDivZero(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
-    UT_CmdBuf.SetUtilParamsCmd.Mult1 = 1;
-    UT_CmdBuf.SetUtilParamsCmd.Mult2 = 2;
-    UT_CmdBuf.SetUtilParamsCmd.Div   = 0;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 0;
 
     /* Execute the function being tested */
-    HS_SetUtilParamsCmd(&UT_CmdBuf.Buf);
+    HS_SetUtilParamsCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_INT32_EQ(HS_CustomData.UtilMult1, 0);
@@ -636,7 +646,7 @@ void HS_SetUtilParamsCmd_Test_Error(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilParamsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -644,12 +654,12 @@ void HS_SetUtilParamsCmd_Test_Error(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
-    UT_CmdBuf.SetUtilParamsCmd.Mult1 = 0;
-    UT_CmdBuf.SetUtilParamsCmd.Mult2 = 2;
-    UT_CmdBuf.SetUtilParamsCmd.Div   = 3;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 0;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 3;
 
     /* Execute the function being tested */
-    HS_SetUtilParamsCmd(&UT_CmdBuf.Buf);
+    HS_SetUtilParamsCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
@@ -675,7 +685,7 @@ void HS_SetUtilParamsCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilParamsCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -683,12 +693,12 @@ void HS_SetUtilParamsCmd_Test_MsgLengthError(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
 
-    UT_CmdBuf.SetUtilParamsCmd.Mult1 = 1;
-    UT_CmdBuf.SetUtilParamsCmd.Mult2 = 2;
-    UT_CmdBuf.SetUtilParamsCmd.Div   = 3;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
+    UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 3;
 
     /* Execute the function being tested */
-    HS_SetUtilParamsCmd(&UT_CmdBuf.Buf);
+    HS_SetUtilParamsCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_INT32_EQ(HS_CustomData.UtilMult1, 0);
@@ -713,7 +723,7 @@ void HS_SetUtilDiagCmd_Test(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_DIAG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilDiagCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilDiagCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -721,10 +731,10 @@ void HS_SetUtilDiagCmd_Test(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
-    UT_CmdBuf.SetUtilDiagCmd.Mask = 2;
+    UT_CustomCmdBuf.SetUtilDiagCmd.Mask = 2;
 
     /* Execute the function being tested */
-    HS_SetUtilDiagCmd(&UT_CmdBuf.Buf);
+    HS_SetUtilDiagCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -751,7 +761,7 @@ void HS_SetUtilDiagCmd_Test_MsgLengthError(void)
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_UTIL_DIAG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetUtilDiagCmd);
+    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilDiagCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
@@ -759,10 +769,10 @@ void HS_SetUtilDiagCmd_Test_MsgLengthError(void)
     /* set message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
 
-    UT_CmdBuf.SetUtilDiagCmd.Mask = 2;
+    UT_CustomCmdBuf.SetUtilDiagCmd.Mask = 2;
 
     /* Execute the function being tested */
-    HS_SetUtilDiagCmd(&UT_CmdBuf.Buf);
+    HS_SetUtilDiagCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");

--- a/unit-test/hs_monitors_tests.c
+++ b/unit-test/hs_monitors_tests.c
@@ -492,7 +492,7 @@ void HS_MonitorApplications_Test_MsgActsNOACT(void)
     HS_AppData.MATablePtr = &MATable[0];
 
     CFE_MSG_Init((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, CFE_SB_ValueToMsgId(HS_CMD_MID),
-                 sizeof(HS_NoArgsCmd_t));
+                 sizeof(HS_NoopCmd_t));
     CFE_MSG_SetFcnCode((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, HS_NOOP_CC);
 
     HS_AppData.AMTablePtr = AMTable;
@@ -539,7 +539,7 @@ void HS_MonitorApplications_Test_MsgActsNOACTDisabled(void)
     HS_AppData.MATablePtr = &MATable[0];
 
     CFE_MSG_Init((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, CFE_SB_ValueToMsgId(HS_CMD_MID),
-                 sizeof(HS_NoArgsCmd_t));
+                 sizeof(HS_NoopCmd_t));
     CFE_MSG_SetFcnCode((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, HS_NOOP_CC);
 
     HS_AppData.AMTablePtr = AMTable;
@@ -591,7 +591,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefault(void)
     HS_AppData.MATablePtr = &MATable[0];
 
     CFE_MSG_Init((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, CFE_SB_ValueToMsgId(HS_CMD_MID),
-                 sizeof(HS_NoArgsCmd_t));
+                 sizeof(HS_NoopCmd_t));
     CFE_MSG_SetFcnCode((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, HS_NOOP_CC);
 
     HS_AppData.AMTablePtr = AMTable;
@@ -650,7 +650,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDisabled(void)
     HS_AppData.MATablePtr = &MATable[0];
 
     CFE_MSG_Init((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, CFE_SB_ValueToMsgId(HS_CMD_MID),
-                 sizeof(HS_NoArgsCmd_t));
+                 sizeof(HS_NoopCmd_t));
     CFE_MSG_SetFcnCode((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, HS_NOOP_CC);
 
     HS_AppData.AMTablePtr = AMTable;
@@ -701,7 +701,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultCoolDown(void)
     HS_AppData.MATablePtr = &MATable[0];
 
     CFE_MSG_Init((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, CFE_SB_ValueToMsgId(HS_CMD_MID),
-                 sizeof(HS_NoArgsCmd_t));
+                 sizeof(HS_NoopCmd_t));
     CFE_MSG_SetFcnCode((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, HS_NOOP_CC);
 
     HS_AppData.AMTablePtr = AMTable;
@@ -752,7 +752,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultDisabled(void)
     HS_AppData.MATablePtr = &MATable[0];
 
     CFE_MSG_Init((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, CFE_SB_ValueToMsgId(HS_CMD_MID),
-                 sizeof(HS_NoArgsCmd_t));
+                 sizeof(HS_NoopCmd_t));
     CFE_MSG_SetFcnCode((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, HS_NOOP_CC);
 
     HS_AppData.AMTablePtr = AMTable;
@@ -803,7 +803,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultNoEvent(void)
     HS_AppData.MATablePtr = &MATable[0];
 
     CFE_MSG_Init((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, CFE_SB_ValueToMsgId(HS_CMD_MID),
-                 sizeof(HS_NoArgsCmd_t));
+                 sizeof(HS_NoopCmd_t));
     CFE_MSG_SetFcnCode((CFE_MSG_Message_t *)&HS_AppData.MATablePtr[0].MsgBuf, HS_NOOP_CC);
 
     HS_AppData.AMTablePtr = AMTable;
@@ -2641,7 +2641,7 @@ void HS_ValidateMATable_Test_UnusedTableEntry(void)
              "MsgActs verify results: good = %%d, bad = %%d, unused = %%d");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    MsgSize   = sizeof(HS_NoArgsCmd_t);
+    MsgSize   = sizeof(HS_NoopCmd_t);
 
     HS_AppData.MATablePtr = MATable;
 
@@ -2693,7 +2693,7 @@ void HS_ValidateMATable_Test_InvalidEnableState(void)
              "MsgActs verify results: good = %%d, bad = %%d, unused = %%d");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    MsgSize   = sizeof(HS_NoArgsCmd_t);
+    MsgSize   = sizeof(HS_NoopCmd_t);
 
     HS_AppData.MATablePtr = MATable;
 
@@ -2750,7 +2750,7 @@ void HS_ValidateMATable_Test_MessageIDTooHigh(void)
              "MsgActs verify results: good = %%d, bad = %%d, unused = %%d");
 
     TestMsgId = CFE_SB_INVALID_MSG_ID;
-    MsgSize   = sizeof(HS_NoArgsCmd_t);
+    MsgSize   = sizeof(HS_NoopCmd_t);
 
     HS_AppData.MATablePtr = MATable;
 
@@ -2862,7 +2862,7 @@ void HS_ValidateMATable_Test_EntryGood(void)
              "MsgActs verify results: good = %%d, bad = %%d, unused = %%d");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    MsgSize   = sizeof(HS_NoArgsCmd_t);
+    MsgSize   = sizeof(HS_NoopCmd_t);
 
     HS_AppData.MATablePtr = MATable;
 

--- a/unit-test/hs_utils_tests.c
+++ b/unit-test/hs_utils_tests.c
@@ -54,13 +54,13 @@ void HS_VerifyMsgLength_Test_Nominal(void)
      */
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_CPUHOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoArgsCmd);
+    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = HS_VerifyMsgLength(&UT_CmdBuf.Buf.Msg, sizeof(HS_NoArgsCmd_t));
+    Result = HS_VerifyMsgLength(&UT_CmdBuf.Msg, sizeof(HS_EnableCpuHogCmd_t));
 
     /* Verify results */
     UtAssert_True(Result == true, "Result == true");
@@ -93,7 +93,7 @@ void HS_VerifyMsgLength_Test_LengthErrorHK(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = HS_VerifyMsgLength(&UT_CmdBuf.Buf.Msg, sizeof(HS_NoArgsCmd_t));
+    Result = HS_VerifyMsgLength(&UT_CmdBuf.Msg, sizeof(HS_SendHkCmd_t));
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");
@@ -134,7 +134,7 @@ void HS_VerifyMsgLength_Test_LengthErrorNonHK(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    Result = HS_VerifyMsgLength(&UT_CmdBuf.Buf.Msg, sizeof(HS_NoArgsCmd_t));
+    Result = HS_VerifyMsgLength(&UT_CmdBuf.Msg, MsgSize + 1);
 
     /* Verify results */
     UtAssert_True(Result == false, "Result == false");

--- a/unit-test/hs_utils_tests.c
+++ b/unit-test/hs_utils_tests.c
@@ -53,7 +53,7 @@ void HS_VerifyMsgLength_Test_Nominal(void)
      * message ID values to return.
      */
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_CPUHOG_CC;
+    FcnCode   = HS_ENABLE_CPU_HOG_CC;
     MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);

--- a/unit-test/stubs/hs_cmds_stubs.c
+++ b/unit-test/stubs/hs_cmds_stubs.c
@@ -101,16 +101,16 @@ void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
     UT_DEFAULT_IMPL(HS_DisableAlivenessCmd);
 }
 
-void HS_EnableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr)
+void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(HS_EnableCPUHogCmd), BufPtr);
-    UT_DEFAULT_IMPL(HS_EnableCPUHogCmd);
+    UT_Stub_RegisterContext(UT_KEY(HS_EnableCpuHogCmd), BufPtr);
+    UT_DEFAULT_IMPL(HS_EnableCpuHogCmd);
 }
 
-void HS_DisableCPUHogCmd(const CFE_SB_Buffer_t *BufPtr)
+void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(HS_DisableCPUHogCmd), BufPtr);
-    UT_DEFAULT_IMPL(HS_DisableCPUHogCmd);
+    UT_Stub_RegisterContext(UT_KEY(HS_DisableCpuHogCmd), BufPtr);
+    UT_DEFAULT_IMPL(HS_DisableCpuHogCmd);
 }
 
 void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr)

--- a/unit-test/utilities/hs_test_utils.h
+++ b/unit-test/utilities/hs_test_utils.h
@@ -68,11 +68,22 @@ extern CFE_ES_WriteToSysLog_context_t context_CFE_ES_WriteToSysLog;
 /* Command buffer typedef for any handler */
 typedef union
 {
-    CFE_SB_Buffer_t       Buf;
-    HS_NoArgsCmd_t        NoArgsCmd;
-    HS_SetMaxResetsCmd_t  SetMaxResetsCmd;
-    HS_SetUtilParamsCmd_t SetUtilParamsCmd;
-    HS_SetUtilDiagCmd_t   SetUtilDiagCmd;
+    CFE_SB_Buffer_t   Buf;
+    CFE_MSG_Message_t Msg;
+
+    HS_NoopCmd_t                 NoopCmd;
+    HS_ResetCmd_t                ResetCmd;
+    HS_EnableAppMonCmd_t         EnableAppMonCmd;
+    HS_DisableAppMonCmd_t        DisableAppMonCmd;
+    HS_EnableEventMonCmd_t       EnableEventMonCmd;
+    HS_DisableEventMonCmd_t      DisableEventMonCmd;
+    HS_EnableAlivenessCmd_t      EnableAlivenessCmd;
+    HS_DisableAlivenessCmd_t     DisableAlivenessCmd;
+    HS_ResetResetsPerformedCmd_t ResetResetsPerformedCmd;
+    HS_EnableCpuHogCmd_t         EnableCpuHogCmd;
+    HS_DisableCpuHogCmd_t        DisableCpuHogCmd;
+    HS_SetMaxResetsCmd_t         SetMaxResetsCmd;
+    HS_SendHkCmd_t               SendHkCmd;
 } UT_CmdBuf_t;
 
 extern UT_CmdBuf_t UT_CmdBuf;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This also updates all data structures and function names to use the proper naming conventions - that is:

 - Structure for each command that matches command name
 - Consistent application of CamelCase and command code name (_CC)

This also fixes a few other unsafe/improper casts regarding message buffers.

Fixes #9

**Testing performed**
Build and run all tests, sanity check HS

**Expected behavior changes**
Safer code, No impact to behavior

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.