### PR TITLE
Fix #77, Combine consecutive, mutually-exclusive status checks

### DIFF
--- a/fsw/inc/hs_events.h
+++ b/fsw/inc/hs_events.h
@@ -648,7 +648,7 @@
  *  \par Cause:
  *
  *  This event message is issued on the first error when a table validation
- *  fails for a application monitor table load.
+ *  fails for an application monitor table load.
  */
 #define HS_AMTVAL_ERR_EID 51
 
@@ -708,7 +708,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a table validation has been
- *  completed for an message actions table load
+ *  completed for a message actions table load
  */
 #define HS_MATVAL_INF_EID 56
 
@@ -720,7 +720,7 @@
  *  \par Cause:
  *
  *  This event message is issued on the first error when a table validation
- *  fails for an message actions table load.
+ *  fails for a message actions table load.
  */
 #define HS_MATVAL_ERR_EID 57
 

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -405,14 +405,6 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
         {
             Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID), HS_AppData.EventPipe,
                                         CFE_SB_DEFAULT_QOS, HS_EVENT_PIPE_DEPTH);
-
-            if (Status != CFE_SUCCESS)
-            {
-                CFE_EVS_SendEvent(HS_EVENTMON_LONG_SUB_EID, CFE_EVS_EventType_ERROR,
-                                  "Event Monitor Enable: Error Subscribing to long-format Events,RC=0x%08X",
-                                  (unsigned int)Status);
-            }
-
             if (Status == CFE_SUCCESS)
             {
                 Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID), HS_AppData.EventPipe,
@@ -424,6 +416,12 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
                                       "Event Monitor Enable: Error Subscribing to short-format Events,RC=0x%08X",
                                       (unsigned int)Status);
                 }
+            }
+            else
+            {
+                CFE_EVS_SendEvent(HS_EVENTMON_LONG_SUB_EID, CFE_EVS_EventType_ERROR,
+                                  "Event Monitor Enable: Error Subscribing to long-format Events,RC=0x%08X",
+                                  (unsigned int)Status);
             }
         }
 
@@ -462,13 +460,6 @@ void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
         {
             Status = CFE_SB_Unsubscribe(CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID), HS_AppData.EventPipe);
 
-            if (Status != CFE_SUCCESS)
-            {
-                CFE_EVS_SendEvent(HS_EVENTMON_LONG_UNSUB_EID, CFE_EVS_EventType_ERROR,
-                                  "Event Monitor Disable: Error Unsubscribing from long-format Events,RC=0x%08X",
-                                  (unsigned int)Status);
-            }
-
             if (Status == CFE_SUCCESS)
             {
                 Status = CFE_SB_Unsubscribe(CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID), HS_AppData.EventPipe);
@@ -479,6 +470,12 @@ void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
                                       "Event Monitor Disable: Error Unsubscribing from short-format Events,RC=0x%08X",
                                       (unsigned int)Status);
                 }
+            }
+            else
+            {
+                CFE_EVS_SendEvent(HS_EVENTMON_LONG_UNSUB_EID, CFE_EVS_EventType_ERROR,
+                                  "Event Monitor Disable: Error Unsubscribing from long-format Events,RC=0x%08X",
+                                  (unsigned int)Status);
             }
         }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #77
Combined 2 consecutive, mutually exclusive status checks (no need to evaluate twice).

Also moved failure the event down to what I believe is a clearer pattern (and more common in cFS) of the successful series of operations together and failure events (in the `else` blocks) all together cascading backwards below.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to logic. No test changes required. Coverage still at 100%.

**Contributor Info**
Avi Weiss @thnkslprpt