### PR TITLE
Fix #79, Use payload sub-struct in all messages

### DIFF
--- a/fsw/inc/hs_custom.h
+++ b/fsw/inc/hs_custom.h
@@ -64,7 +64,7 @@ typedef struct
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - The #HS_UTIL_DIAG_REPORT_EID informational event message will be
  *         generated when the command is executed
  *
@@ -73,7 +73,7 @@ typedef struct
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *
  *  \par Criticality
  *       None
@@ -92,7 +92,7 @@ typedef struct
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -100,7 +100,7 @@ typedef struct
  *       - Any parameter is set to 0.
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *
  *  \par Criticality
  *       None
@@ -119,14 +119,14 @@ typedef struct
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *
  *  \par Criticality
  *       None

--- a/fsw/inc/hs_msg.h
+++ b/fsw/inc/hs_msg.h
@@ -162,6 +162,15 @@ typedef struct
 } HS_DisableCpuHogCmd_t;
 
 /**
+ *  \brief Set Max Resets Payload
+ */
+typedef struct
+{
+    uint16 MaxResets; /**< \brief Maximum Resets */
+    uint16 Padding;   /**< \brief Structure padding */
+} HS_SetMaxResets_Payload_t;
+
+/**
  *  \brief Set Max Resets Command
  *
  *  For command details see #HS_SET_MAX_RESETS_CC
@@ -170,8 +179,7 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
-    uint16 MaxResets; /**< \brief Maximum Resets */
-    uint16 Padding;   /**< \brief Structure padding */
+    HS_SetMaxResets_Payload_t Payload;
 } HS_SetMaxResetsCmd_t;
 
 /**
@@ -192,12 +200,10 @@ typedef struct
  */
 
 /**
- *  \brief Housekeeping Packet Structure
+ *  \brief Housekeeping Packet Payload
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
-
     uint8  CmdCount;              /**< \brief HS Application Command Counter */
     uint8  CmdErrCount;           /**< \brief HS Application Command Error Counter */
     uint8  CurrentAppMonState;    /**< \brief Status of HS Application Monitor */
@@ -219,6 +225,16 @@ typedef struct
     uint32 UtilCpuPeak; /**< \brief Current CPU Utilization Peak */
 
     uint32 ExeCounts[HS_MAX_EXEC_CNT_SLOTS]; /**< \brief Execution Counters */
+} HS_HkTlm_Payload_t;
+
+/**
+ *  \brief Housekeeping Packet Structure
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Header */
+
+    HS_HkTlm_Payload_t Payload;
 } HS_HkPacket_t;
 
 /**\}*/

--- a/fsw/inc/hs_msgdefs.h
+++ b/fsw/inc/hs_msgdefs.h
@@ -78,7 +78,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - The #HS_NOOP_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -87,7 +87,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -109,7 +109,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will be cleared
+ *       - #HS_HkTlm_Payload_t.CmdCount will be cleared
  *       - The #HS_RESET_DBG_EID debug event message will be
  *         generated when the command is executed
  *
@@ -118,7 +118,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -140,8 +140,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentAppMonState will be set to Enabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentAppMonState will be set to Enabled
  *       - The #HS_ENABLE_APPMON_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -150,7 +150,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -172,8 +172,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentAppMonState will be set to Disabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentAppMonState will be set to Disabled
  *       - The #HS_DISABLE_APPMON_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -182,7 +182,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -204,8 +204,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentEventMonState will be set to Enabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentEventMonState will be set to Enabled
  *       - The #HS_ENABLE_EVENTMON_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -214,7 +214,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -236,8 +236,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentEventMonState will be set to Disabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentEventMonState will be set to Disabled
  *       - The #HS_DISABLE_EVENTMON_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -246,7 +246,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -268,8 +268,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentAlivenessState will be set to Enabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentAlivenessState will be set to Enabled
  *       - The #HS_ENABLE_ALIVENESS_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -278,7 +278,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -300,8 +300,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentAlivenessState will be set to Disabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentAlivenessState will be set to Disabled
  *       - The #HS_DISABLE_ALIVENESS_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -310,7 +310,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -332,8 +332,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.ResetsPerformed will be set to 0
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.ResetsPerformed will be set to 0
  *       - The #HS_RESET_RESETS_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -342,7 +342,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -364,8 +364,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.MaxResets will be set to the provided value
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.MaxResets will be set to the provided value
  *       - The #HS_SET_MAX_RESETS_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -374,7 +374,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -396,8 +396,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentCPUHogState will be set to Enabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentCPUHogState will be set to Enabled
  *       - The #HS_ENABLE_CPUHOG_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -406,7 +406,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -428,8 +428,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #HS_HkPacket_t.CmdCount will increment
- *       - #HS_HkPacket_t.CurrentCPUHogState will be set to Disabled
+ *       - #HS_HkTlm_Payload_t.CmdCount will increment
+ *       - #HS_HkTlm_Payload_t.CurrentCPUHogState will be set to Disabled
  *       - The #HS_DISABLE_CPUHOG_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -438,7 +438,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #HS_HkPacket_t.CmdErrCount will increment
+ *       - #HS_HkTlm_Payload_t.CmdErrCount will increment
  *       - Error specific event message #HS_LEN_ERR_EID
  *
  *  \par Criticality

--- a/fsw/src/hs_app.c
+++ b/fsw/src/hs_app.c
@@ -478,7 +478,7 @@ int32 HS_TblInit(void)
         for (TableIndex = 0; TableIndex < HS_MAX_EXEC_CNT_SLOTS; TableIndex++)
         {
             /* HS 8005.1 Report 0xFFFFFFFF for all entries */
-            HS_AppData.HkPacket.ExeCounts[TableIndex] = HS_INVALID_EXECOUNT;
+            HS_AppData.HkPacket.Payload.ExeCounts[TableIndex] = HS_INVALID_EXECOUNT;
         }
     }
 

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -524,6 +524,8 @@ void HS_HousekeepingReq_Test_InvalidEventMon(void)
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     uint32            TableIndex;
 
+    HS_HkTlm_Payload_t *PayloadPtr;
+
     memset(EMTable, 0, sizeof(EMTable));
 
     HS_AppData.EMTablePtr = EMTable;
@@ -565,27 +567,28 @@ void HS_HousekeepingReq_Test_InvalidEventMon(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 1, "HS_AppData.HkPacket.InvalidEventMonCount == 1");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 1, "PayloadPtr->InvalidEventMonCount == 1");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
@@ -618,6 +621,8 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint8             ExpectedStatusFlags = 0;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -669,30 +674,30 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.StatusFlags == ExpectedStatusFlags,
-                  "HS_AppData.HkPacket.StatusFlags == ExpectedStatusFlags");
+    UtAssert_True(PayloadPtr->StatusFlags == ExpectedStatusFlags, "PayloadPtr->StatusFlags == ExpectedStatusFlags");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
@@ -711,6 +716,8 @@ void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint32            TableIndex;
     CFE_ES_TaskInfo_t TaskInfo;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     int i;
 
@@ -768,32 +775,33 @@ void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
 
-    UtAssert_True(HS_AppData.HkPacket.ExeCounts[0] == 5, "HS_AppData.HkPacket.ExeCounts[0] == 5");
+    UtAssert_True(PayloadPtr->ExeCounts[0] == 5, "PayloadPtr->ExeCounts[0] == 5");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -810,6 +818,8 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
     uint32            TableIndex;
     CFE_ES_TaskInfo_t TaskInfo;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -865,32 +875,33 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
 
-    UtAssert_True(HS_AppData.HkPacket.ExeCounts[0] == 5, "HS_AppData.HkPacket.ExeCounts[0] == 5");
+    UtAssert_True(PayloadPtr->ExeCounts[0] == 5, "PayloadPtr->ExeCounts[0] == 5");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -907,6 +918,8 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
     uint32            TableIndex;
     CFE_ES_TaskInfo_t TaskInfo;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -963,33 +976,33 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
 
-    UtAssert_True(HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT,
-                  "HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT");
+    UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -1005,6 +1018,8 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint32            TableIndex;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -1058,33 +1073,33 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
 
-    UtAssert_True(HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT,
-                  "HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT");
+    UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -1101,6 +1116,8 @@ void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
     uint32            TableIndex;
     CFE_ES_TaskInfo_t TaskInfo;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -1154,33 +1171,33 @@ void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
 
-    UtAssert_True(HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT,
-                  "HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT");
+    UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -1196,6 +1213,8 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint32            TableIndex;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -1243,33 +1262,33 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
 
-    UtAssert_True(HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT,
-                  "HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT");
+    UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -1285,6 +1304,8 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint32            TableIndex;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -1335,33 +1356,33 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
 
-    UtAssert_True(HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT,
-                  "HS_AppData.HkPacket.ExeCounts[0] == HS_INVALID_EXECOUNT");
+    UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
@@ -1377,6 +1398,8 @@ void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint8             ExpectedStatusFlags = 0;
     int               i;
+
+    HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
     memset(XCTable, 0, sizeof(XCTable));
@@ -1429,30 +1452,30 @@ void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
     HS_HousekeepingReq(&UT_CmdBuf.Buf);
 
     /* Verify results */
-    UtAssert_True(HS_AppData.HkPacket.CmdCount == 1, "HS_AppData.HkPacket.CmdCount == 1");
-    UtAssert_True(HS_AppData.HkPacket.CmdErrCount == 2, "HS_AppData.HkPacket.CmdErrCount == 2");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAppMonState == 3, "HS_AppData.HkPacket.CurrentAppMonState == 3");
-    UtAssert_True(HS_AppData.HkPacket.CurrentEventMonState == 4, "HS_AppData.HkPacket.CurrentEventMonState == 4");
-    UtAssert_True(HS_AppData.HkPacket.CurrentAlivenessState == 5, "HS_AppData.HkPacket.CurrentAlivenessState == 5");
-    UtAssert_True(HS_AppData.HkPacket.CurrentCPUHogState == 6, "HS_AppData.HkPacket.CurrentCPUHogState == 6");
-    UtAssert_True(HS_AppData.HkPacket.ResetsPerformed == 7, "HS_AppData.HkPacket.ResetsPerformed == 7");
-    UtAssert_True(HS_AppData.HkPacket.MaxResets == 8, "HS_AppData.HkPacket.MaxResets == 8");
-    UtAssert_True(HS_AppData.HkPacket.EventsMonitoredCount == 9, "HS_AppData.HkPacket.EventsMonitoredCount == 9");
-    UtAssert_True(HS_AppData.HkPacket.MsgActExec == 10, "HS_AppData.HkPacket.MsgActExec == 10");
-    UtAssert_True(HS_AppData.HkPacket.InvalidEventMonCount == 0, "HS_AppData.HkPacket.InvalidEventMonCount == 0");
+    PayloadPtr = &HS_AppData.HkPacket.Payload;
+    UtAssert_True(PayloadPtr->CmdCount == 1, "PayloadPtr->CmdCount == 1");
+    UtAssert_True(PayloadPtr->CmdErrCount == 2, "PayloadPtr->CmdErrCount == 2");
+    UtAssert_True(PayloadPtr->CurrentAppMonState == 3, "PayloadPtr->CurrentAppMonState == 3");
+    UtAssert_True(PayloadPtr->CurrentEventMonState == 4, "PayloadPtr->CurrentEventMonState == 4");
+    UtAssert_True(PayloadPtr->CurrentAlivenessState == 5, "PayloadPtr->CurrentAlivenessState == 5");
+    UtAssert_True(PayloadPtr->CurrentCPUHogState == 6, "PayloadPtr->CurrentCPUHogState == 6");
+    UtAssert_True(PayloadPtr->ResetsPerformed == 7, "PayloadPtr->ResetsPerformed == 7");
+    UtAssert_True(PayloadPtr->MaxResets == 8, "PayloadPtr->MaxResets == 8");
+    UtAssert_True(PayloadPtr->EventsMonitoredCount == 9, "PayloadPtr->EventsMonitoredCount == 9");
+    UtAssert_True(PayloadPtr->MsgActExec == 10, "PayloadPtr->MsgActExec == 10");
+    UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.StatusFlags == ExpectedStatusFlags,
-                  "HS_AppData.HkPacket.StatusFlags == ExpectedStatusFlags");
+    UtAssert_True(PayloadPtr->StatusFlags == ExpectedStatusFlags, "PayloadPtr->StatusFlags == ExpectedStatusFlags");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[0] == 0, "HS_AppData.HkPacket.AppMonEnables[0] == 0");
+    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] ==
                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE) / 2");
 
-    UtAssert_True(HS_AppData.HkPacket.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
+    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] ==
                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
                   "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
                   "HS_BITS_PER_APPMON_ENABLE");
@@ -2560,6 +2583,9 @@ void HS_SetMaxResetsCmd_Test(void)
     size_t            MsgSize;
     int32             strCmpResult;
     char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+
+    HS_SetMaxResets_Payload_t *PayloadPtr;
+
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Max Resets Performable by HS has been set to %%d");
 
@@ -2573,7 +2599,9 @@ void HS_SetMaxResetsCmd_Test(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
-    UT_CmdBuf.SetMaxResetsCmd.MaxResets = 5;
+    PayloadPtr = &UT_CmdBuf.SetMaxResetsCmd.Payload;
+
+    PayloadPtr->MaxResets = 5;
 
     /* Execute the function being tested */
     HS_SetMaxResetsCmd(&UT_CmdBuf.Buf);
@@ -2600,6 +2628,8 @@ void HS_SetMaxResetsCmd_Test_MsgLengthError(void)
     CFE_MSG_FcnCode_t FcnCode;
     size_t            MsgSize;
 
+    HS_SetMaxResets_Payload_t *PayloadPtr;
+
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_SET_MAX_RESETS_CC;
     MsgSize   = sizeof(UT_CmdBuf.SetMaxResetsCmd);
@@ -2610,7 +2640,9 @@ void HS_SetMaxResetsCmd_Test_MsgLengthError(void)
     /* ignore dummy message length check */
     UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
 
-    UT_CmdBuf.SetMaxResetsCmd.MaxResets = 5;
+    PayloadPtr = &UT_CmdBuf.SetMaxResetsCmd.Payload;
+
+    PayloadPtr->MaxResets = 5;
 
     /* Execute the function being tested */
     HS_SetMaxResetsCmd(&UT_CmdBuf.Buf);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Puts the CMD/TLM content in a member struct called "Payload".  This makes it consistent with other CFE modules and provides a predictably named member for determining the position of non-header content.

Fixes #79

**Testing performed**
Build and run all tests, sanity check app in CFE

**Expected behavior changes**
None.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
