### PR TITLE
Fix #43, Refactor MAT table to be more portable

### DIFF
--- a/fsw/tables/hs_mat.c
+++ b/fsw/tables/hs_mat.c
@@ -30,41 +30,83 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_MsgActs_Tbl", HS_APP_NAME ".MsgActs_Tbl", "HS MsgActs Table", "hs_mat.tbl",
-                                     (sizeof(HS_MATEntry_t) * HS_MAX_MSG_ACT_TYPES)};
+#include "cfe_tbl_msg.h"
+#include "cfe_es_msg.h"
+#include "cfe_msgids.h"
 
-HS_MATEntry_t HS_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
+CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_Default_MsgActs_Tbl", HS_APP_NAME ".MsgActs_Tbl", "HS MsgActs Table",
+                                     "hs_mat.tbl", (sizeof(HS_MATEntry_t) * HS_MAX_MSG_ACT_TYPES)};
+
+/* Checksum for each desired command - Note that if checksum is enabled, real values (non-zero) must be input */
+#ifndef CFE_TBL_NOOP_CKSUM
+#define CFE_TBL_NOOP_CKSUM 0x00
+#endif
+
+#ifndef CFE_ES_NOOP_CKSUM
+#define CFE_ES_NOOP_CKSUM 0x00
+#endif
+
+/* Desired Command Types. Note - HS_MAX_MSG_ACT_SIZE should be sized appropriately given desired cmd types */
+typedef union
+{
+    CFE_TBL_NoopCmd_t cmd1;   /**< \brief Desired cmd1 type */
+    CFE_ES_NoopCmd_t  cmd2;   /**< \brief Desired cmd2 type */
+    HS_MATMsgBuf_t    MsgBuf; /**< \brief Message Buffer for alignment */
+} HS_Message;
+
+/* MAT Table Entry Structure */
+typedef struct
+{
+    uint16     EnableState; /**< \brief If entry contains message */
+    uint16     Cooldown;    /**< \brief Maximum rate at which message can be sent */
+    HS_Message HsMsg;       /**< \brief HS Message/Command Entry */
+} HS_MatTableEntry_t;
+
+/* Helper macro to get size of structure elements */
+#define HS_MEMBER_SIZE(member) (sizeof(((HS_Message *)0)->member))
+
+HS_MatTableEntry_t HS_Default_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
     /*          EnableState               Cooldown   Message */
 
-    /*   0 */ {HS_MAT_STATE_DISABLED,
-               10,
-               {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    /*   0 */
+    {.EnableState = HS_MAT_STATE_ENABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd1.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
     /*   1 */
-    {HS_MAT_STATE_DISABLED,
-     10,
-     {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    {.EnableState = HS_MAT_STATE_ENABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd2.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_ES_CMD_MID, HS_MEMBER_SIZE(cmd2), CFE_ES_NOOP_CC, CFE_ES_NOOP_CKSUM)},
     /*   2 */
-    {HS_MAT_STATE_DISABLED,
-     10,
-     {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    {.EnableState = HS_MAT_STATE_DISABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd1.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
     /*   3 */
-    {HS_MAT_STATE_DISABLED,
-     10,
-     {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    {.EnableState = HS_MAT_STATE_DISABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd1.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
     /*   4 */
-    {HS_MAT_STATE_DISABLED,
-     10,
-     {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    {.EnableState = HS_MAT_STATE_DISABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd1.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
     /*   5 */
-    {HS_MAT_STATE_DISABLED,
-     10,
-     {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    {.EnableState = HS_MAT_STATE_DISABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd1.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
     /*   6 */
-    {HS_MAT_STATE_DISABLED,
-     10,
-     {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    {.EnableState = HS_MAT_STATE_DISABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd1.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
     /*   7 */
-    {HS_MAT_STATE_DISABLED,
-     10,
-     {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}},
+    {.EnableState = HS_MAT_STATE_DISABLED,
+     .Cooldown    = 10,
+     .HsMsg.cmd1.CommandHeader =
+         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+
 };


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
 The updated MAT table uses the CFE_MSG_CMD_HDR_INIT macro to make MAT commands header agnostic.  Further this implementation makes the tables endian agnostic.

Fixes #43 

**Testing performed**
Steps taken to test the contribution:
1. Modified hs_monitors.c to print each table entry when the table gets read in by FSW.
2. Ran a test to confirm that the expected commands/MIDs get read in when the table is validated.
3. Ran a test to ensure that the expected commands get sent when the table is used/executed.

**Expected behavior changes**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
