### PR TITLE
Fix #81, use separate dispatcher for messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ project(CFS_HS C)
 set(APP_SRC_FILES
   fsw/src/hs_monitors.c
   fsw/src/hs_utils.c
+  fsw/src/hs_dispatch.c
   fsw/src/hs_custom.c
+  fsw/src/hs_custom_dispatch.c
   fsw/src/hs_app.c
   fsw/src/hs_cmds.c
 )

--- a/fsw/src/hs_app.c
+++ b/fsw/src/hs_app.c
@@ -35,6 +35,7 @@
 #include "hs_custom_internal.h"
 #include "hs_version.h"
 #include "hs_cmds.h"
+#include "hs_dispatch.h"
 #include "hs_verify.h"
 
 /************************************************************************

--- a/fsw/src/hs_cmds.h
+++ b/fsw/src/hs_cmds.h
@@ -35,21 +35,6 @@
  ************************************************************************/
 
 /**
- * \brief Process a command pipe message
- *
- *  \par Description
- *       Processes a single software bus command pipe message. Checks
- *       the message and command IDs and calls the appropriate routine
- *       to handle the message.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param[in] BufPtr Pointer to Software Bus buffer
- */
-void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr);
-
-/**
  * \brief Reset counters
  *
  *  \par Description
@@ -89,7 +74,7 @@ void HS_AcquirePointers(void);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  */
-void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr);
+void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Noop command

--- a/fsw/src/hs_custom_dispatch.c
+++ b/fsw/src/hs_custom_dispatch.c
@@ -1,0 +1,126 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Health and Safety (HS) application custom component.
+ *   This custom code is designed to work without modification; however the
+ *   nature of specific platforms may make it desirable to modify this code
+ *   to work in a more efficient way, or to provide greater functionality.
+ */
+
+/*************************************************************************
+** Includes
+*************************************************************************/
+#include "cfe.h"
+#include "cfe_psp.h"
+#include "osapi.h"
+#include "hs_app.h"
+#include "hs_cmds.h"
+#include "hs_msg.h"
+#include "hs_utils.h"
+#include "hs_custom.h"
+#include "hs_custom_internal.h"
+#include "hs_dispatch.h"
+#include "hs_events.h"
+#include "hs_monitors.h"
+#include "hs_perfids.h"
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Report Utilization Diagnostics Information                      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_ReportDiagVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_ReportDiagCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_ReportDiagCmd(BufPtr);
+    }
+}
+
+void HS_SetUtilParamsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_SetUtilParamsCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_SetUtilParamsCmd(BufPtr);
+    }
+}
+
+void HS_SetUtilDiagVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_SetUtilDiagCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_SetUtilDiagCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Processes any additional commands                               */
+/*                                                                 */
+/* NOTE: For complete prolog information, see 'hs_custom.h'        */
+/*                                                                 */
+/* This function MUST return CFE_SUCCESS if any command is found   */
+/* and must NOT return CFE_SUCCESS if no command was found         */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+int32 HS_CustomCommands(const CFE_SB_Buffer_t *BufPtr)
+{
+    int32             Status      = CFE_SUCCESS;
+    CFE_MSG_FcnCode_t CommandCode = 0;
+
+    CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
+
+    switch (CommandCode)
+    {
+        case HS_REPORT_DIAG_CC:
+            HS_ReportDiagVerifyDispatch(BufPtr);
+            break;
+
+        case HS_SET_UTIL_PARAMS_CC:
+            HS_SetUtilParamsVerifyDispatch(BufPtr);
+            break;
+
+        case HS_SET_UTIL_DIAG_CC:
+            HS_SetUtilDiagVerifyDispatch(BufPtr);
+            break;
+
+        default:
+            Status = CFE_STATUS_BAD_COMMAND_CODE;
+            break;
+
+    } /* end CommandCode switch */
+
+    return Status;
+}

--- a/fsw/src/hs_custom_dispatch.h
+++ b/fsw/src/hs_custom_dispatch.h
@@ -19,48 +19,42 @@
 
 /**
  * @file
- *   Utility functions for the cFS Health and Safety (HS) application.
+ *   Specification for the CFS Health and Safety (HS) mission specific
+ *   custom function private interface
  */
-#ifndef HS_UTILS_H
-#define HS_UTILS_H
+#ifndef HS_CUSTOM_DISPATCH_H
+#define HS_CUSTOM_DISPATCH_H
 
 /*************************************************************************
  * Includes
- *************************************************************************/
+ ************************************************************************/
 #include "cfe.h"
+#include "hs_platform_cfg.h"
+#include "hs_custom_internal.h"
+
+/*************************************************************************
+ * Exported Functions
+ *************************************************************************/
 
 /**
- * \brief Verify AMT Action Type
+ * \brief Process Custom Commands
  *
  *  \par Description
- *       Checks if the specified value is a valid AMT Action Type.
+ *       This function allows for hs_custom.c to define custom commands.
+ *       It will be called for any command code not already allocated
+ *       to a Health and Safety command. If a custom command is found,
+ *       then it is responsible for incrementing the command processed
+ *       or command error counter as appropriate.
  *
  *  \par Assumptions, External Events, and Notes:
- *       None
+ *       If a command is found, this function MUST return #CFE_SUCCESS,
+ *       otherwise is must not return #CFE_SUCCESS
  *
- *  \param[in] ActionType Action type to validate
+ *  \param[in] BufPtr Pointer to Software Bus buffer
  *
- *  \return Boolean action valid response
- *  \retval true  Action type valid
- *  \retval false Action type not valid
+ *  \return Execution status, see \ref CFEReturnCodes
+ *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-bool HS_AMTActionIsValid(uint16 ActionType);
-
-/**
- * \brief Verify EMT Action Type
- *
- *  \par Description
- *       Checks if the specified value is a valid EMT Action Type.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param[in] ActionType Action type to validate
- *
- *  \return Boolean action valid response
- *  \retval true  Action type valid
- *  \retval false Action type not valid
- */
-bool HS_EMTActionIsValid(uint16 ActionType);
+int32 HS_CustomCommands(const CFE_SB_Buffer_t *BufPtr);
 
 #endif

--- a/fsw/src/hs_custom_internal.h
+++ b/fsw/src/hs_custom_internal.h
@@ -137,27 +137,6 @@ void HS_CustomMonitorUtilization(void);
 int32 HS_CustomGetUtil(void);
 
 /**
- * \brief Process Custom Commands
- *
- *  \par Description
- *       This function allows for hs_custom.c to define custom commands.
- *       It will be called for any command code not already allocated
- *       to a Health and Safety command. If a custom command is found,
- *       then it is responsible for incrementing the command processed
- *       or command error counter as appropriate.
- *
- *  \par Assumptions, External Events, and Notes:
- *       If a command is found, this function MUST return #CFE_SUCCESS,
- *       otherwise is must not return #CFE_SUCCESS
- *
- *  \param[in] BufPtr Pointer to Software Bus buffer
- *
- *  \return Execution status, see \ref CFEReturnCodes
- *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
- */
-int32 HS_CustomCommands(const CFE_SB_Buffer_t *BufPtr);
-
-/**
  * \brief Task that increments counters
  *
  *  \par Description
@@ -221,7 +200,7 @@ void HS_MarkIdleCallback(void);
  *  \par Assumptions, External Events, and Notes:
  *       None
  */
-void HS_UtilDiagReport(void);
+void HS_ReportDiagCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Set Utilization Parameters

--- a/fsw/src/hs_dispatch.c
+++ b/fsw/src/hs_dispatch.c
@@ -1,0 +1,424 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   CFS Health and Safety (HS) command handling routines
+ */
+
+/************************************************************************
+** Includes
+*************************************************************************/
+#include "hs_app.h"
+#include "hs_cmds.h"
+#include "hs_msgids.h"
+#include "hs_msgdefs.h"
+#include "hs_events.h"
+#include "hs_dispatch.h"
+#include "hs_custom_dispatch.h"
+#include "hs_version.h"
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Verify message packet length                                    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+bool HS_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
+{
+    bool              result       = true;
+    size_t            ActualLength = 0;
+    CFE_MSG_FcnCode_t CommandCode  = 0;
+    CFE_SB_MsgId_t    MessageID    = CFE_SB_INVALID_MSG_ID;
+
+    /*
+    ** Verify the message packet length...
+    */
+
+    CFE_MSG_GetSize(MsgPtr, &ActualLength);
+    if (ExpectedLength != ActualLength)
+    {
+        CFE_MSG_GetMsgId(MsgPtr, &MessageID);
+        CFE_MSG_GetFcnCode(MsgPtr, &CommandCode);
+
+        if (CFE_SB_MsgIdToValue(MessageID) == HS_SEND_HK_MID)
+        {
+            /*
+            ** For a bad HK request, just send the event. We only increment
+            ** the error counter for ground commands and not internal messages.
+            */
+            CFE_EVS_SendEvent(HS_HKREQ_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Invalid HK request msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
+                              (unsigned long)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode, (int)ActualLength,
+                              (int)ExpectedLength);
+        }
+        else
+        {
+            /*
+            ** All other cases, increment error counter
+            */
+            CFE_EVS_SendEvent(HS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
+                              (unsigned long)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode, (int)ActualLength,
+                              (int)ExpectedLength);
+            HS_AppData.CmdErrCount++;
+        }
+
+        result = false;
+    }
+
+    return result;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Process a command pipe message                                  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
+{
+    CFE_MSG_FcnCode_t CommandCode = 0;
+    CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
+
+    CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+
+    switch (CFE_SB_MsgIdToValue(MessageID))
+    {
+        /*
+        ** Housekeeping telemetry request
+        */
+        case HS_SEND_HK_MID:
+            HS_SendHkVerifyDispatch(BufPtr);
+            break;
+
+        /*
+        ** HS application commands...
+        */
+        case HS_CMD_MID:
+
+            CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
+
+            switch (CommandCode)
+            {
+                case HS_NOOP_CC:
+                    HS_NoopVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_RESET_CC:
+                    HS_ResetVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_ENABLE_APP_MON_CC:
+                    HS_EnableAppMonVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_DISABLE_APP_MON_CC:
+                    HS_DisableAppMonVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_ENABLE_EVENT_MON_CC:
+                    HS_EnableEventMonVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_DISABLE_EVENT_MON_CC:
+                    HS_DisableEventMonVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_ENABLE_ALIVENESS_CC:
+                    HS_EnableAlivenessVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_DISABLE_ALIVENESS_CC:
+                    HS_DisableAlivenessVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_RESET_RESETS_PERFORMED_CC:
+                    HS_ResetResetsPerformedVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_SET_MAX_RESETS_CC:
+                    HS_SetMaxResetsVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_ENABLE_CPU_HOG_CC:
+                    HS_EnableCpuHogVerifyDispatch(BufPtr);
+                    break;
+
+                case HS_DISABLE_CPU_HOG_CC:
+                    HS_DisableCpuHogVerifyDispatch(BufPtr);
+                    break;
+
+                default:
+                    if (HS_CustomCommands(BufPtr) != CFE_SUCCESS)
+                    {
+                        CFE_EVS_SendEvent(HS_CC_ERR_EID, CFE_EVS_EventType_ERROR,
+                                          "Invalid command code: ID = 0x%08lX, CC = %d",
+                                          (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
+
+                        HS_AppData.CmdErrCount++;
+                    }
+                    break;
+
+            } /* end CommandCode switch */
+            break;
+
+        /*
+        ** Unrecognized Message ID
+        */
+        default:
+            HS_AppData.CmdErrCount++;
+            CFE_EVS_SendEvent(HS_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command pipe message ID: 0x%08lX",
+                              (unsigned long)CFE_SB_MsgIdToValue(MessageID));
+            break;
+
+    } /* end MessageID switch */
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Housekeeping request                                            */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_SendHkCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_SendHkCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Noop command                                                    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_NoopCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_NoopCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Reset counters command                                          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_ResetVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_ResetCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_ResetCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Enable applications monitor command                             */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_EnableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_EnableAppMonCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_EnableAppMonCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Disable applications monitor command                            */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_DisableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_DisableAppMonCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_DisableAppMonCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Enable events monitor command                                   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_EnableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_EnableEventMonCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_EnableEventMonCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Disable event monitor command                                   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_DisableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_DisableEventMonCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_DisableEventMonCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Enable aliveness indicator command                              */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_EnableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_EnableAlivenessCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_EnableAlivenessCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Disable aliveness indicator command                             */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_DisableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_DisableAlivenessCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_DisableAlivenessCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Enable cpu hogging indicator command                            */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_EnableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_EnableCpuHogCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_EnableCpuHogCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Disable cpu hogging indicator command                           */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_DisableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_DisableCpuHogCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_DisableCpuHogCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Reset processor resets performed count command                  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_ResetResetsPerformedVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_ResetResetsPerformedCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_ResetResetsPerformedCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Set max processor resets command                                */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_SetMaxResetsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HS_SetMaxResetsCmd_t);
+
+    /*
+    ** Verify message packet length
+    */
+    if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
+    {
+        HS_SetMaxResetsCmd(BufPtr);
+    }
+}

--- a/fsw/src/hs_dispatch.h
+++ b/fsw/src/hs_dispatch.h
@@ -1,0 +1,189 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   Specification for the CFS Health and Safety (HS) routines that
+ *   handle command processing
+ */
+#ifndef HS_DISPATCH_H
+#define HS_DISPATCH_H
+
+/*************************************************************************
+ * Includes
+ ************************************************************************/
+#include "cfe.h"
+
+/*************************************************************************
+ * Exported Functions
+ ************************************************************************/
+
+/**
+ * \brief Process a command pipe message
+ *
+ *  \par Description
+ *       Processes a single software bus command pipe message. Checks
+ *       the message and command IDs and calls the appropriate routine
+ *       to handle the message.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ *  \param[in] BufPtr Pointer to Software Bus buffer
+ */
+void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Verify message length
+ *
+ *  \par Description
+ *       Checks if the actual length of a software bus message matches
+ *       the expected length and sends an error event if a mismatch
+ *       occurs
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ *  \param[in] MsgPtr         Message Pointer
+ *  \param[in] ExpectedLength Expected length
+ *
+ *  \return Boolean message length matches response
+ *  \retval true  Length matches expected
+ *  \retval false Length does not match expected
+ *
+ *  \sa #HS_LEN_ERR_EID
+ */
+bool HS_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
+
+/**
+ * \brief Housekeeping dispatcher
+ *
+ * Verifies and processes the received command
+ */
+void HS_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Noop command dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_NOOP_CC
+ */
+void HS_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Reset counters dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_RESET_CC
+ */
+void HS_ResetVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Enable application monitor dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_ENABLE_APP_MON_CC
+ */
+void HS_EnableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Disable application monitor dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_DISABLE_APP_MON_CC
+ */
+void HS_DisableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Enable critical events monitor dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_ENABLE_EVENT_MON_CC
+ */
+void HS_EnableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Disable critical events monitor dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_DISABLE_EVENT_MON_CC
+ */
+void HS_DisableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Enable aliveness indicator dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_ENABLE_ALIVENESS_CC
+ */
+void HS_EnableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Disable aliveness indicator dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_DISABLE_ALIVENESS_CC
+ */
+void HS_DisableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Enable CPU Hogging indicator dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_ENABLE_CPU_HOG_CC
+ */
+void HS_EnableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Disable CPU Hogging indicator dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_DISABLE_CPU_HOG_CC
+ */
+void HS_DisableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Reset resets performed dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_SET_MAX_RESETS_CC
+ */
+void HS_ResetResetsPerformedVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Set max resets dispatcher
+ *
+ * Verifies and processes the received command
+ *
+ *  \sa #HS_RESET_RESETS_PERFORMED_CC
+ */
+void HS_SetMaxResetsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr);
+
+#endif

--- a/fsw/src/hs_utils.c
+++ b/fsw/src/hs_utils.c
@@ -35,57 +35,6 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Verify message packet length                                    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-bool HS_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
-{
-    bool              result       = true;
-    size_t            ActualLength = 0;
-    CFE_MSG_FcnCode_t CommandCode  = 0;
-    CFE_SB_MsgId_t    MessageID    = CFE_SB_INVALID_MSG_ID;
-
-    /*
-    ** Verify the message packet length...
-    */
-
-    CFE_MSG_GetSize(MsgPtr, &ActualLength);
-    if (ExpectedLength != ActualLength)
-    {
-        CFE_MSG_GetMsgId(MsgPtr, &MessageID);
-        CFE_MSG_GetFcnCode(MsgPtr, &CommandCode);
-
-        if (CFE_SB_MsgIdToValue(MessageID) == HS_SEND_HK_MID)
-        {
-            /*
-            ** For a bad HK request, just send the event. We only increment
-            ** the error counter for ground commands and not internal messages.
-            */
-            CFE_EVS_SendEvent(HS_HKREQ_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Invalid HK request msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
-                              (unsigned long)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode, (int)ActualLength,
-                              (int)ExpectedLength);
-        }
-        else
-        {
-            /*
-            ** All other cases, increment error counter
-            */
-            CFE_EVS_SendEvent(HS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d, Expected = %d",
-                              (unsigned long)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode, (int)ActualLength,
-                              (int)ExpectedLength);
-            HS_AppData.CmdErrCount++;
-        }
-
-        result = false;
-    }
-
-    return result;
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
 /* Verify AMT Action Type                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -10,12 +10,14 @@
 add_cfe_coverage_stubs("hs_internal"
   utilities/hs_test_utils.c
   stubs/hs_global_stubs.c
-  stubs/hs_custom_global_stubs.c
   stubs/hs_app_stubs.c
   stubs/hs_cmds_stubs.c
-  stubs/hs_custom_internal_stubs.c
+  stubs/hs_dispatch_stubs.c
   stubs/hs_monitors_stubs.c
   stubs/hs_utils_stubs.c
+  stubs/hs_custom_global_stubs.c
+  stubs/hs_custom_internal_stubs.c
+  stubs/hs_custom_dispatch_stubs.c
 )
 
 # Link with the cfe core stubs and unit test assert libs

--- a/unit-test/hs_app_tests.c
+++ b/unit-test/hs_app_tests.c
@@ -24,6 +24,7 @@
 #include "hs_app.h"
 #include "hs_test_utils.h"
 #include "hs_msgids.h"
+#include "hs_dispatch.h"
 
 /* UT includes */
 #include "uttest.h"

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -52,471 +52,7 @@ int32 HS_CMDS_TEST_CFE_ES_GetTaskInfoHook(void *UserObj, int32 StubRetcode, uint
     return CFE_SUCCESS;
 }
 
-void HS_AppPipe_Test_SendHK(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
-
-    memset(EMTable, 0, sizeof(EMTable));
-
-    HS_AppData.EMTablePtr = EMTable;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_SEND_HK_MID);
-    FcnCode   = 0;
-    MsgSize   = sizeof(UT_CmdBuf.SendHkCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_Noop(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_NOOP_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoopCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    /* Assert */
-    UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(HS_AppData.CmdErrCount, 0);
-    UtAssert_INT32_EQ(HS_AppData.CmdCount, 1);
-}
-
-void HS_AppPipe_Test_Reset(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_RESET_CC;
-    MsgSize   = sizeof(UT_CmdBuf.ResetCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_EnableAppMon(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
-
-    memset(AMTable, 0, sizeof(AMTable));
-
-    HS_AppData.AMTablePtr = AMTable;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_APP_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_DisableAppMon(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
-
-    HS_AppData.AMTablePtr = AMTable;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_APP_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_EnableEventMon(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
-
-    HS_AppData.EMTablePtr = EMTable;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENT_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_DisableEventMon(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
-
-    HS_AppData.EMTablePtr = EMTable;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENT_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_EnableAliveness(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableAlivenessCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_DisableAliveness(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableAlivenessCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_ResetResetsPerformed(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_RESET_RESETS_PERFORMED_CC;
-    MsgSize   = sizeof(UT_CmdBuf.ResetResetsPerformedCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_SetMaxResets(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_SET_MAX_RESETS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetMaxResetsCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_EnableCPUHog(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_CPU_HOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_DisableCPUHog(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_CPU_HOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_InvalidCC(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    int32             strCmpResult;
-    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Invalid command code: ID = 0x%%08lX, CC = %%d");
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = 99;
-    MsgSize   = sizeof(UT_CmdBuf);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* bypass custom command check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_CustomCommands), !CFE_SUCCESS);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_CC_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_InvalidCCNoEvent(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = 99;
-    MsgSize   = sizeof(UT_CmdBuf);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdErrCount == 0, "HS_AppData.CmdErrCount == 0");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_AppPipe_Test_InvalidMID(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    int32             strCmpResult;
-    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Invalid command pipe message ID: 0x%%08lX");
-
-    TestMsgId = CFE_SB_INVALID_MSG_ID;
-    FcnCode   = HS_NOOP_CC;
-    MsgSize   = sizeof(UT_CmdBuf);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    HS_AppPipe(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_MID_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_HousekeepingReq_Test_InvalidEventMon(void)
+void HS_SendHkCmd_Test_InvalidEventMon(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -544,9 +80,6 @@ void HS_HousekeepingReq_Test_InvalidEventMon(void)
     /* Fail first, succeed on second */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, -1);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     HS_AppData.CmdCount                = 1;
     HS_AppData.CmdErrCount             = 2;
     HS_AppData.CurrentAppMonState      = 3;
@@ -564,7 +97,7 @@ void HS_HousekeepingReq_Test_InvalidEventMon(void)
     }
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -598,21 +131,7 @@ void HS_HousekeepingReq_Test_InvalidEventMon(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_InvalidMsgLength(void)
-{
-    /* set message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
-
-    /* No errors generated for an invalid message length */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
+void HS_SendHkCmd_Test_AllFlagsEnabled(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -642,9 +161,6 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     HS_AppData.EMTablePtr[0].ActionType = HS_EMT_ACT_NOACT;
 
     HS_AppData.CmdCount                = 1;
@@ -671,7 +187,7 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
     ExpectedStatusFlags |= HS_CDS_IN_USE;
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -707,7 +223,7 @@ void HS_HousekeepingReq_Test_AllFlagsEnabled(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
+void HS_SendHkCmd_Test_ResourceTypeAppMain(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -763,16 +279,13 @@ void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
     /* Causes line "Status = CFE_ES_GetTaskInfo(&TaskInfo, TaskId)" to be reached */
     UT_SetDeferredRetcode(UT_KEY(OS_TaskGetIdByName), 1, OS_SUCCESS);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Sets TaskInfo.ExecutionCounter to 5, returns CFE_SUCCESS, goes to line "ExeCount = TaskInfo.ExecutionCounter" */
     TaskInfo.ExecutionCounter = 5;
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetTaskInfo), &TaskInfo, sizeof(TaskInfo), false);
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -808,7 +321,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppMain(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
+void HS_SendHkCmd_Test_ResourceTypeAppChild(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -863,16 +376,13 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
     /* Causes line "Status = CFE_ES_GetTaskInfo(&TaskInfo, TaskId)" to be reached */
     UT_SetDeferredRetcode(UT_KEY(OS_TaskGetIdByName), 1, OS_SUCCESS);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Sets TaskInfo.ExecutionCounter to 5, returns CFE_SUCCESS, goes to line "ExeCount = TaskInfo.ExecutionCounter" */
     TaskInfo.ExecutionCounter = 5;
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetTaskInfo), &TaskInfo, sizeof(TaskInfo), false);
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -908,7 +418,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChild(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
+void HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -963,9 +473,6 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
     /* Causes line "Status = CFE_ES_GetTaskInfo(&TaskInfo, TaskId)" to be skipped */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetTaskIDByName), 1, -1);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Sets TaskInfo.ExecutionCounter to 5, returns CFE_SUCCESS, goes to line "ExeCount = TaskInfo.ExecutionCounter" */
     TaskInfo.ExecutionCounter = 5;
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetTaskInfo), &TaskInfo, sizeof(TaskInfo), false);
@@ -973,7 +480,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -1009,7 +516,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
+void HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1063,14 +570,11 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
     /* Causes line "Status = CFE_ES_GetTaskInfo(&TaskInfo, TaskId)" to be skipped */
     UT_SetDeferredRetcode(UT_KEY(OS_TaskGetIdByName), 1, OS_SUCCESS);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Sets CFE_ES_GetTaskInfo to return an error and bypass "ExeCount = TaskInfo.ExecutionCounter" */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetTaskInfo), 1, -1);
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -1106,7 +610,7 @@ void HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
+void HS_SendHkCmd_Test_ResourceTypeDevice(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1161,14 +665,11 @@ void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
     /* Causes line "Status = CFE_ES_GetTaskInfo(&TaskInfo, TaskId)" to be reached */
     UT_SetDeferredRetcode(UT_KEY(OS_TaskGetIdByName), 1, OS_SUCCESS);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Sets TaskInfo.ExecutionCounter to 5, returns CFE_SUCCESS, goes to line "ExeCount = TaskInfo.ExecutionCounter" */
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -1204,7 +705,7 @@ void HS_HousekeepingReq_Test_ResourceTypeDevice(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeISR(void)
+void HS_SendHkCmd_Test_ResourceTypeISR(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1233,9 +734,6 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.EMTablePtr[0].ActionType = HS_EMT_ACT_NOACT;
 
@@ -1259,7 +757,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCT_TYPE_ISR;
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -1295,7 +793,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISR(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
+void HS_SendHkCmd_Test_ResourceTypeISRGenCounterError(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1324,9 +822,6 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.EMTablePtr[0].ActionType = HS_EMT_ACT_NOACT;
 
@@ -1353,7 +848,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_GetGenCounterIDByName), -1);
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -1389,7 +884,7 @@ void HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
+void HS_SendHkCmd_Test_ResourceTypeUnknown(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1420,9 +915,6 @@ void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     HS_AppData.EMTablePtr[0].ActionType = HS_EMT_ACT_NOACT;
 
     HS_AppData.CmdCount                = 1;
@@ -1449,7 +941,7 @@ void HS_HousekeepingReq_Test_ResourceTypeUnknown(void)
     ExpectedStatusFlags |= HS_CDS_IN_USE;
 
     /* Execute the function being tested */
-    HS_HousekeepingReq(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.Buf);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -1501,9 +993,6 @@ void HS_Noop_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Execute the function being tested */
     HS_NoopCmd(&UT_CmdBuf.Buf);
 
@@ -1523,33 +1012,6 @@ void HS_Noop_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_Noop_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_NOOP_CC;
-    MsgSize   = sizeof(UT_CmdBuf.NoopCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    /* Execute the function being tested */
-    HS_NoopCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_ResetCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1565,9 +1027,6 @@ void HS_ResetCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     /* Execute the function being tested */
     HS_ResetCmd(&UT_CmdBuf.Buf);
@@ -1588,40 +1047,8 @@ void HS_ResetCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_ResetCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_RESET_CC;
-    MsgSize   = sizeof(UT_CmdBuf.ResetCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    /* Execute the function being tested */
-    HS_ResetCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_ResetCounters_Test(void)
 {
-    /* No setup required for this test */
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Execute the function being tested */
     HS_ResetCounters();
 
@@ -1655,9 +1082,6 @@ void HS_EnableAppMonCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     HS_AppData.AMTablePtr = AMTable;
 
     /* Execute the function being tested */
@@ -1682,41 +1106,6 @@ void HS_EnableAppMonCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_EnableAppMonCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_APP_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* set message length check error */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.AMTablePtr = AMTable;
-
-    HS_AppData.CurrentAppMonState = HS_STATE_DISABLED;
-
-    /* Execute the function being tested */
-    HS_EnableAppMonCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentAppMonState == HS_STATE_DISABLED,
-                  "HS_AppData.CurrentAppMonState == HS_STATE_DISABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_DisableAppMonCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1732,9 +1121,6 @@ void HS_DisableAppMonCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     /* Execute the function being tested */
     HS_DisableAppMonCmd(&UT_CmdBuf.Buf);
@@ -1758,38 +1144,6 @@ void HS_DisableAppMonCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_DisableAppMonCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_APP_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.CurrentAppMonState = HS_STATE_ENABLED;
-
-    /* Execute the function being tested */
-    HS_DisableAppMonCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentAppMonState == HS_STATE_ENABLED,
-                  "HS_AppData.CurrentAppMonState == HS_STATE_ENABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_EnableEventMonCmd_Test_Disabled(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1805,9 +1159,6 @@ void HS_EnableEventMonCmd_Test_Disabled(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentEventMonState = HS_STATE_DISABLED;
 
@@ -1833,38 +1184,6 @@ void HS_EnableEventMonCmd_Test_Disabled(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_EnableEventMonCmd_Test_DisabledMsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_EVENT_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableEventMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.CurrentEventMonState = HS_STATE_DISABLED;
-
-    /* Execute the function being tested */
-    HS_EnableEventMonCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentEventMonState == HS_STATE_DISABLED,
-                  "HS_AppData.CurrentEventMonState == HS_STATE_DISABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -1880,9 +1199,6 @@ void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentEventMonState = HS_STATE_ENABLED;
 
@@ -1929,9 +1245,6 @@ void HS_EnableEventMonCmd_Test_SubscribeLongError(void)
 
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 1, -1);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Execute the function being tested */
     HS_EnableEventMonCmd(&UT_CmdBuf.Buf);
 
@@ -1975,9 +1288,6 @@ void HS_EnableEventMonCmd_Test_SubscribeShortError(void)
 
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 2, -1);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Execute the function being tested */
     HS_EnableEventMonCmd(&UT_CmdBuf.Buf);
 
@@ -2015,9 +1325,6 @@ void HS_DisableEventMonCmd_Test_Enabled(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentEventMonState = HS_STATE_ENABLED;
 
@@ -2058,9 +1365,6 @@ void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentEventMonState = HS_STATE_DISABLED;
 
@@ -2107,9 +1411,6 @@ void HS_DisableEventMonCmd_Test_UnsubscribeLongError(void)
 
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Unsubscribe), 1, -1);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Execute the function being tested */
     HS_DisableEventMonCmd(&UT_CmdBuf.Buf);
 
@@ -2153,9 +1454,6 @@ void HS_DisableEventMonCmd_Test_UnsubscribeShortError(void)
 
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Unsubscribe), 2, -1);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Execute the function being tested */
     HS_DisableEventMonCmd(&UT_CmdBuf.Buf);
 
@@ -2178,38 +1476,6 @@ void HS_DisableEventMonCmd_Test_UnsubscribeShortError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_DisableEventMonCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_EVENT_MON_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableEventMonCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.CurrentEventMonState = HS_STATE_ENABLED;
-
-    /* Execute the function being tested */
-    HS_DisableEventMonCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentEventMonState == HS_STATE_ENABLED,
-                  "HS_AppData.CurrentEventMonState == HS_STATE_ENABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_EnableAlivenessCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -2225,9 +1491,6 @@ void HS_EnableAlivenessCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentAlivenessState = HS_STATE_DISABLED;
 
@@ -2253,38 +1516,6 @@ void HS_EnableAlivenessCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_EnableAlivenessCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableAlivenessCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.CurrentAlivenessState = HS_STATE_DISABLED;
-
-    /* Execute the function being tested */
-    HS_EnableAlivenessCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentAlivenessState == HS_STATE_DISABLED,
-                  "HS_AppData.CurrentAlivenessState == HS_STATE_DISABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_DisableAlivenessCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -2300,9 +1531,6 @@ void HS_DisableAlivenessCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentAlivenessState = HS_STATE_ENABLED;
 
@@ -2328,38 +1556,6 @@ void HS_DisableAlivenessCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_DisableAlivenessCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_ALIVENESS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableAlivenessCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.CurrentAlivenessState = HS_STATE_ENABLED;
-
-    /* Execute the function being tested */
-    HS_DisableAlivenessCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentAlivenessState == HS_STATE_ENABLED,
-                  "HS_AppData.CurrentAlivenessState == HS_STATE_ENABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_EnableCpuHogCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -2375,9 +1571,6 @@ void HS_EnableCpuHogCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
 
@@ -2403,38 +1596,6 @@ void HS_EnableCpuHogCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_EnableCpuHogCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_CPU_HOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
-
-    /* Execute the function being tested */
-    HS_EnableCpuHogCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentCPUHogState == HS_STATE_DISABLED,
-                  "HS_AppData.CurrentCPUHogState == HS_STATE_DISABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_DisableCpuHogCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -2450,9 +1611,6 @@ void HS_DisableCpuHogCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
 
@@ -2478,38 +1636,6 @@ void HS_DisableCpuHogCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_DisableCpuHogCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_DISABLE_CPU_HOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
-
-    /* Execute the function being tested */
-    HS_DisableCpuHogCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    UtAssert_True(HS_AppData.CurrentCPUHogState == HS_STATE_ENABLED,
-                  "HS_AppData.CurrentCPUHogState == HS_STATE_ENABLED");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_ResetResetsPerformedCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -2527,9 +1653,6 @@ void HS_ResetResetsPerformedCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     /* Execute the function being tested */
     HS_ResetResetsPerformedCmd(&UT_CmdBuf.Buf);
 
@@ -2546,33 +1669,6 @@ void HS_ResetResetsPerformedCmd_Test(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_ResetResetsPerformedCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_RESET_RESETS_PERFORMED_CC;
-    MsgSize   = sizeof(UT_CmdBuf.ResetResetsPerformedCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    /* Execute the function being tested */
-    HS_ResetResetsPerformedCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
 
@@ -2596,9 +1692,6 @@ void HS_SetMaxResetsCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     PayloadPtr = &UT_CmdBuf.SetMaxResetsCmd.Payload;
 
     PayloadPtr->MaxResets = 5;
@@ -2619,39 +1712,6 @@ void HS_SetMaxResetsCmd_Test(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_SetMaxResetsCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    HS_SetMaxResets_Payload_t *PayloadPtr;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_SET_MAX_RESETS_CC;
-    MsgSize   = sizeof(UT_CmdBuf.SetMaxResetsCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    PayloadPtr = &UT_CmdBuf.SetMaxResetsCmd.Payload;
-
-    PayloadPtr->MaxResets = 5;
-
-    /* Execute the function being tested */
-    HS_SetMaxResetsCmd(&UT_CmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
 
@@ -3227,68 +2287,36 @@ void HS_MsgActsStatusRefresh_Test(void)
  */
 void UtTest_Setup(void)
 {
-    UtTest_Add(HS_AppPipe_Test_SendHK, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_SendHK");
-    UtTest_Add(HS_AppPipe_Test_Noop, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_Noop");
-    UtTest_Add(HS_AppPipe_Test_Reset, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_Reset");
-    UtTest_Add(HS_AppPipe_Test_EnableAppMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableAppMon");
-    UtTest_Add(HS_AppPipe_Test_DisableAppMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableAppMon");
-    UtTest_Add(HS_AppPipe_Test_EnableEventMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableEventMon");
-    UtTest_Add(HS_AppPipe_Test_DisableEventMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableEventMon");
-    UtTest_Add(HS_AppPipe_Test_EnableAliveness, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableAliveness");
-    UtTest_Add(HS_AppPipe_Test_DisableAliveness, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableAliveness");
-    UtTest_Add(HS_AppPipe_Test_ResetResetsPerformed, HS_Test_Setup, HS_Test_TearDown,
-               "HS_AppPipe_Test_ResetResetsPerformed");
-    UtTest_Add(HS_AppPipe_Test_SetMaxResets, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_SetMaxResets");
-    UtTest_Add(HS_AppPipe_Test_EnableCPUHog, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableCPUHog");
-    UtTest_Add(HS_AppPipe_Test_DisableCPUHog, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableCPUHog");
-    UtTest_Add(HS_AppPipe_Test_InvalidCC, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_InvalidCC");
-    UtTest_Add(HS_AppPipe_Test_InvalidCCNoEvent, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_InvalidCCNoEvent");
-    UtTest_Add(HS_AppPipe_Test_InvalidMID, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_InvalidMID");
+    UtTest_Add(HS_SendHkCmd_Test_InvalidEventMon, HS_Test_Setup, HS_Test_TearDown, "HS_SendHkCmd_Test_InvalidEventMon");
 
-    UtTest_Add(HS_HousekeepingReq_Test_InvalidEventMon, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_InvalidEventMon");
-    UtTest_Add(HS_HousekeepingReq_Test_InvalidMsgLength, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_InvalidMsgLength");
-
-    UtTest_Add(HS_HousekeepingReq_Test_AllFlagsEnabled, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_AllFlagsEnabled");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeAppMain, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeAppMain");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeAppChild, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeAppChild");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeAppChildTaskIdError");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeAppChildTaskInfoError");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeDevice, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeDevice");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeISR, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeISR");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeISRGenCounterError");
-    UtTest_Add(HS_HousekeepingReq_Test_ResourceTypeUnknown, HS_Test_Setup, HS_Test_TearDown,
-               "HS_HousekeepingReq_Test_ResourceTypeAppMain");
+    UtTest_Add(HS_SendHkCmd_Test_AllFlagsEnabled, HS_Test_Setup, HS_Test_TearDown, "HS_SendHkCmd_Test_AllFlagsEnabled");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeAppMain, HS_Test_Setup, HS_Test_TearDown,
+               "HS_SendHkCmd_Test_ResourceTypeAppMain");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeAppChild, HS_Test_Setup, HS_Test_TearDown,
+               "HS_SendHkCmd_Test_ResourceTypeAppChild");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError, HS_Test_Setup, HS_Test_TearDown,
+               "HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError, HS_Test_Setup, HS_Test_TearDown,
+               "HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeDevice, HS_Test_Setup, HS_Test_TearDown,
+               "HS_SendHkCmd_Test_ResourceTypeDevice");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeISR, HS_Test_Setup, HS_Test_TearDown, "HS_SendHkCmd_Test_ResourceTypeISR");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeISRGenCounterError, HS_Test_Setup, HS_Test_TearDown,
+               "HS_SendHkCmd_Test_ResourceTypeISRGenCounterError");
+    UtTest_Add(HS_SendHkCmd_Test_ResourceTypeUnknown, HS_Test_Setup, HS_Test_TearDown,
+               "HS_SendHkCmd_Test_ResourceTypeAppMain");
 
     UtTest_Add(HS_Noop_Test, HS_Test_Setup, HS_Test_TearDown, "HS_Noop_Test");
-    UtTest_Add(HS_Noop_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown, "HS_Noop_Test_MsgLengthError");
 
     UtTest_Add(HS_ResetCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_ResetCmd_Test");
-    UtTest_Add(HS_ResetCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown, "HS_ResetCmd_Test_MsgLengthError");
-
     UtTest_Add(HS_ResetCounters_Test, HS_Test_Setup, HS_Test_TearDown, "HS_ResetCounters_Test");
 
     UtTest_Add(HS_EnableAppMonCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableAppMonCmd_Test");
-    UtTest_Add(HS_EnableAppMonCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_EnableAppMonCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_DisableAppMonCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableAppMonCmd_Test");
-    UtTest_Add(HS_DisableAppMonCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_DisableAppMonCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_EnableEventMonCmd_Test_Disabled, HS_Test_Setup, HS_Test_TearDown,
                "HS_EnableEventMonCmd_Test_Disabled");
-    UtTest_Add(HS_EnableEventMonCmd_Test_DisabledMsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_EnableEventMonCmd_Test_DisabledMsgLengthError");
 
     UtTest_Add(HS_EnableEventMonCmd_Test_AlreadyEnabled, HS_Test_Setup, HS_Test_TearDown,
                "HS_EnableEventMonCmd_Test_AlreadyEnabled");
@@ -3305,32 +2333,18 @@ void UtTest_Setup(void)
                "HS_DisableEventMonCmd_Test_UnsubscribeLongError");
     UtTest_Add(HS_DisableEventMonCmd_Test_UnsubscribeShortError, HS_Test_Setup, HS_Test_TearDown,
                "HS_DisableEventMonCmd_Test_UnsubscribeShortError");
-    UtTest_Add(HS_DisableEventMonCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_DisableEventMonCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_EnableAlivenessCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableAlivenessCmd_Test");
-    UtTest_Add(HS_EnableAlivenessCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_EnableAlivenessCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_DisableAlivenessCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableAlivenessCmd_Test");
-    UtTest_Add(HS_DisableAlivenessCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_DisableAlivenessCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_EnableCpuHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableCpuHogCmd_Test");
-    UtTest_Add(HS_EnableCpuHogCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_EnableCpuHogCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_DisableCpuHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableCpuHogCmd_Test");
-    UtTest_Add(HS_DisableCpuHogCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_DisableCpuHogCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_ResetResetsPerformedCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_ResetResetsPerformedCmd_Test");
-    UtTest_Add(HS_ResetResetsPerformedCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_ResetResetsPerformedCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_SetMaxResetsCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_SetMaxResetsCmd_Test");
-    UtTest_Add(HS_SetMaxResetsCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_SetMaxResetsCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_AcquirePointers_Test_Nominal, HS_Test_Setup, HS_Test_TearDown, "HS_AcquirePointers_Test_Nominal");
     UtTest_Add(HS_AcquirePointers_Test_ErrorsWithAppMonLoadedAndEventMonLoadedEnabled, HS_Test_Setup, HS_Test_TearDown,

--- a/unit-test/hs_custom_dispatch_tests.c
+++ b/unit-test/hs_custom_dispatch_tests.c
@@ -1,0 +1,144 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "hs_platform_cfg.h"
+#include "hs_custom.h"
+#include "hs_test_utils.h"
+#include "hs_custom_internal.h"
+#include "hs_custom_dispatch.h"
+#include "hs_dispatch.h"
+#include "hs_msgids.h"
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+
+/* Command buffer typedef for any handler */
+typedef union
+{
+    CFE_SB_Buffer_t       Buf;
+    HS_ReportDiagCmd_t    ReportDiagCmd;
+    HS_SetUtilParamsCmd_t SetUtilParamsCmd;
+    HS_SetUtilDiagCmd_t   SetUtilDiagCmd;
+} UT_CustomCmdBuf_t;
+
+UT_CustomCmdBuf_t UT_CustomCmdBuf;
+
+void HS_CustomCommands_Test_ReportDiagCmd(void)
+{
+    CFE_MSG_FcnCode_t FcnCode;
+
+    FcnCode = HS_REPORT_DIAG_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(HS_CustomCommands(&UT_CustomCmdBuf.Buf), CFE_SUCCESS);
+    UtAssert_STUB_COUNT(HS_ReportDiagCmd, 1);
+
+    /* Now with an invalid size */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(HS_CustomCommands(&UT_CustomCmdBuf.Buf), CFE_SUCCESS);
+
+    /* Should NOT have invoked the handler this time */
+    UtAssert_STUB_COUNT(HS_ReportDiagCmd, 1);
+}
+
+void HS_CustomCommands_Test_SetUtilParamsCmd(void)
+{
+    CFE_MSG_FcnCode_t FcnCode;
+
+    FcnCode = HS_SET_UTIL_PARAMS_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(HS_CustomCommands(&UT_CustomCmdBuf.Buf), CFE_SUCCESS);
+    UtAssert_STUB_COUNT(HS_SetUtilParamsCmd, 1);
+
+    /* Now with an invalid size */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(HS_CustomCommands(&UT_CustomCmdBuf.Buf), CFE_SUCCESS);
+
+    /* Should NOT have invoked the handler this time */
+    UtAssert_STUB_COUNT(HS_SetUtilParamsCmd, 1);
+}
+
+void HS_CustomCommands_Test_SetUtilDiagCmd(void)
+{
+    CFE_MSG_FcnCode_t FcnCode;
+
+    FcnCode = HS_SET_UTIL_DIAG_CC;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(HS_CustomCommands(&UT_CustomCmdBuf.Buf), CFE_SUCCESS);
+    UtAssert_STUB_COUNT(HS_SetUtilDiagCmd, 1);
+
+    /* Now with an invalid size */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(HS_CustomCommands(&UT_CustomCmdBuf.Buf), CFE_SUCCESS);
+
+    /* Should NOT have invoked the handler this time */
+    UtAssert_STUB_COUNT(HS_SetUtilDiagCmd, 1);
+}
+
+void HS_CustomCommands_Test_InvalidCommandCode(void)
+{
+    CFE_MSG_FcnCode_t FcnCode;
+
+    FcnCode = 99;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+
+    /* Execute the function being tested */
+    UtAssert_INT32_EQ(HS_CustomCommands(&UT_CustomCmdBuf.Buf), CFE_STATUS_BAD_COMMAND_CODE);
+}
+
+/*
+ * Register the test cases to execute with the unit test tool
+ */
+void UtTest_Setup(void)
+{
+    UtTest_Add(HS_CustomCommands_Test_ReportDiagCmd, HS_Test_Setup, HS_Test_TearDown,
+               "HS_CustomCommands_Test_ReportDiagCmd");
+    UtTest_Add(HS_CustomCommands_Test_SetUtilParamsCmd, HS_Test_Setup, HS_Test_TearDown,
+               "HS_CustomCommands_Test_SetUtilParamsCmd");
+    UtTest_Add(HS_CustomCommands_Test_SetUtilDiagCmd, HS_Test_Setup, HS_Test_TearDown,
+               "HS_CustomCommands_Test_SetUtilDiagCmd");
+    UtTest_Add(HS_CustomCommands_Test_InvalidCommandCode, HS_Test_Setup, HS_Test_TearDown,
+               "HS_CustomCommands_Test_InvalidCommandCode");
+}

--- a/unit-test/hs_custom_tests.c
+++ b/unit-test/hs_custom_tests.c
@@ -272,119 +272,7 @@ void HS_CustomMonitorUtilization_Test(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
-void HS_CustomCommands_Test_UtilDiagReport(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    int32             Result;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_REPORT_DIAG_CC;
-    MsgSize   = sizeof(UT_CustomCmdBuf);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_CustomCommands_Test_SetUtilParamsCmd(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    int32             Result;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_CustomCommands_Test_SetUtilDiagCmd(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    int32             Result;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_SET_UTIL_DIAG_CC;
-    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilDiagCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
-    /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    /* Generates 1 message we don't care about in this test */
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_CustomCommands_Test_InvalidCommandCode(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    int32             Result;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = 99;
-    MsgSize   = sizeof(UT_CustomCmdBuf);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* Execute the function being tested */
-    Result = HS_CustomCommands(&UT_CustomCmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(Result == !CFE_SUCCESS, "Result == !CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_UtilDiagReport_Test(void)
+void HS_ReportDiagCmd_Test(void)
 {
     uint32 i;
     int32  strCmpResult;
@@ -404,7 +292,7 @@ void HS_UtilDiagReport_Test(void)
     HS_CustomData.UtilMask = 0xFFFFFFFE;
 
     /* Execute the function being tested */
-    HS_UtilDiagReport();
+    HS_ReportDiagCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_UTIL_DIAG_REPORT_EID);
@@ -420,7 +308,7 @@ void HS_UtilDiagReport_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_UtilDiagReport_Test_Loops(void)
+void HS_ReportDiagCmd_Test_Loops(void)
 {
     /* ensure all values produce unique time jumps */
     HS_CustomData.UtilArray[0]  = 0xFFFFFFFE;
@@ -443,7 +331,7 @@ void HS_UtilDiagReport_Test_Loops(void)
     HS_CustomData.UtilMask = 0;
 
     /* Execute the function being tested */
-    HS_UtilDiagReport();
+    HS_ReportDiagCmd(&UT_CustomCmdBuf.Buf);
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_UTIL_DIAG_REPORT_EID);
@@ -513,9 +401,6 @@ void HS_SetUtilParamsCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
     UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 3;
@@ -558,9 +443,6 @@ void HS_SetUtilParamsCmd_Test_NominalMultZero(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 0;
@@ -605,9 +487,6 @@ void HS_SetUtilParamsCmd_Test_NominalDivZero(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
     UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 0;
@@ -651,9 +530,6 @@ void HS_SetUtilParamsCmd_Test_Error(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
-
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 0;
     UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
     UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 3;
@@ -677,40 +553,6 @@ void HS_SetUtilParamsCmd_Test_Error(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void HS_SetUtilParamsCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_SET_UTIL_PARAMS_CC;
-    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilParamsCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    UT_CustomCmdBuf.SetUtilParamsCmd.Mult1 = 1;
-    UT_CustomCmdBuf.SetUtilParamsCmd.Mult2 = 2;
-    UT_CustomCmdBuf.SetUtilParamsCmd.Div   = 3;
-
-    /* Execute the function being tested */
-    HS_SetUtilParamsCmd(&UT_CustomCmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_INT32_EQ(HS_CustomData.UtilMult1, 0);
-    UtAssert_INT32_EQ(HS_CustomData.UtilMult2, 0);
-    UtAssert_INT32_EQ(HS_CustomData.UtilDiv, 0);
-    UtAssert_INT32_EQ(HS_AppData.CmdCount, 0);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_SetUtilDiagCmd_Test(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -727,9 +569,6 @@ void HS_SetUtilDiagCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* ignore dummy message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), true);
 
     UT_CustomCmdBuf.SetUtilDiagCmd.Mask = 2;
 
@@ -750,35 +589,6 @@ void HS_SetUtilDiagCmd_Test(void)
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_SetUtilDiagCmd_Test_MsgLengthError(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_SET_UTIL_DIAG_CC;
-    MsgSize   = sizeof(UT_CustomCmdBuf.SetUtilDiagCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* set message length check */
-    UT_SetDefaultReturnValue(UT_KEY(HS_VerifyMsgLength), false);
-
-    UT_CustomCmdBuf.SetUtilDiagCmd.Mask = 2;
-
-    /* Execute the function being tested */
-    HS_SetUtilDiagCmd(&UT_CustomCmdBuf.Buf);
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
 }
 
@@ -805,17 +615,8 @@ void UtTest_Setup(void)
 
     UtTest_Add(HS_CustomMonitorUtilization_Test, HS_Test_Setup, HS_Test_TearDown, "HS_CustomMonitorUtilization_Test");
 
-    UtTest_Add(HS_CustomCommands_Test_UtilDiagReport, HS_Test_Setup, HS_Test_TearDown,
-               "HS_CustomCommands_Test_UtilDiagReport");
-    UtTest_Add(HS_CustomCommands_Test_SetUtilParamsCmd, HS_Test_Setup, HS_Test_TearDown,
-               "HS_CustomCommands_Test_SetUtilParamsCmd");
-    UtTest_Add(HS_CustomCommands_Test_SetUtilDiagCmd, HS_Test_Setup, HS_Test_TearDown,
-               "HS_CustomCommands_Test_SetUtilDiagCmd");
-    UtTest_Add(HS_CustomCommands_Test_InvalidCommandCode, HS_Test_Setup, HS_Test_TearDown,
-               "HS_CustomCommands_Test_InvalidCommandCode");
-
-    UtTest_Add(HS_UtilDiagReport_Test, HS_Test_Setup, HS_Test_TearDown, "HS_UtilDiagReport_Test");
-    UtTest_Add(HS_UtilDiagReport_Test_Loops, HS_Test_Setup, HS_Test_TearDown, "HS_UtilDiagReport_Test_Loops");
+    UtTest_Add(HS_ReportDiagCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_ReportDiagCmd_Test");
+    UtTest_Add(HS_ReportDiagCmd_Test_Loops, HS_Test_Setup, HS_Test_TearDown, "HS_ReportDiagCmd_Test_Loops");
 
     UtTest_Add(HS_CustomGetUtil_Test, HS_Test_Setup, HS_Test_TearDown, "HS_CustomGetUtil_Test");
     UtTest_Add(HS_CustomGetUtil_Test_DivZero, HS_Test_Setup, HS_Test_TearDown, "HS_CustomGetUtil_Test_DivZero");
@@ -826,10 +627,6 @@ void UtTest_Setup(void)
     UtTest_Add(HS_SetUtilParamsCmd_Test_NominalDivZero, HS_Test_Setup, HS_Test_TearDown,
                "HS_SetUtilParamsCmd_Test_NominalDivZero");
     UtTest_Add(HS_SetUtilParamsCmd_Test_Error, HS_Test_Setup, HS_Test_TearDown, "HS_SetUtilParamsCmd_Test_Error");
-    UtTest_Add(HS_SetUtilParamsCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_SetUtilParamsCmd_Test_MsgLengthError");
 
     UtTest_Add(HS_SetUtilDiagCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_SetUtilDiagCmd_Test");
-    UtTest_Add(HS_SetUtilDiagCmd_Test_MsgLengthError, HS_Test_Setup, HS_Test_TearDown,
-               "HS_SetUtilDiagCmd_Test_MsgLengthError");
 }

--- a/unit-test/hs_dispatch_tests.c
+++ b/unit-test/hs_dispatch_tests.c
@@ -1,0 +1,402 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "hs_cmds.h"
+#include "hs_test_utils.h"
+#include "hs_dispatch.h"
+#include "hs_custom_dispatch.h"
+#include "hs_msgids.h"
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+#include "cfe.h"
+#include "cfe_msgids.h"
+
+/*
+ * Helper functions
+ */
+static void HS_Dispatch_Test_SetupMsg(CFE_SB_MsgId_t MsgId, CFE_MSG_FcnCode_t FcnCode, size_t MsgSize)
+{
+    /* Note some paths get the MsgId/FcnCode multiple times, so register accordingly, just in case */
+    CFE_SB_MsgId_t    RegMsgId[2]   = {MsgId, MsgId};
+    CFE_MSG_FcnCode_t RegFcnCode[2] = {FcnCode, FcnCode};
+    size_t            RegMsgSize[2] = {MsgSize, MsgSize};
+
+    UT_ResetState(UT_KEY(CFE_MSG_GetMsgId));
+    UT_ResetState(UT_KEY(CFE_MSG_GetFcnCode));
+    UT_ResetState(UT_KEY(CFE_MSG_GetSize));
+
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), RegMsgId, sizeof(RegMsgId), true);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), RegFcnCode, sizeof(RegFcnCode), true);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), RegMsgSize, sizeof(RegMsgSize), true);
+}
+
+/*
+ * Function Definitions
+ */
+
+void HS_VerifyMsgLength_Test(void)
+{
+    /* Nominal */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), 0, 1);
+
+    /* Execute the function being tested */
+    UtAssert_BOOL_TRUE(HS_VerifyMsgLength(&UT_CmdBuf.Msg, 1));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+    /* Error on SEND_HK */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_SEND_HK_MID), 0, 1);
+
+    /* Execute the function being tested */
+    UtAssert_BOOL_FALSE(HS_VerifyMsgLength(&UT_CmdBuf.Msg, 2));
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_HKREQ_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+    UtAssert_UINT8_EQ(HS_AppData.CmdErrCount, 0);
+
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), 0, 1);
+
+    /* Execute the function being tested */
+    UtAssert_BOOL_FALSE(HS_VerifyMsgLength(&UT_CmdBuf.Msg, 2));
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
+    UtAssert_UINT8_EQ(HS_AppData.CmdErrCount, 1);
+}
+
+void HS_AppPipe_Test_SendHK(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_SEND_HK_MID), 0, sizeof(UT_CmdBuf.SendHkCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should have invoked the handler */
+    UtAssert_STUB_COUNT(HS_SendHkCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_SEND_HK_MID), 0, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler this time */
+    UtAssert_STUB_COUNT(HS_SendHkCmd, 1);
+}
+
+void HS_AppPipe_Test_Noop(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_NOOP_CC, sizeof(UT_CmdBuf.NoopCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should have invoked the handler */
+    UtAssert_STUB_COUNT(HS_NoopCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_NOOP_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler this time */
+    UtAssert_STUB_COUNT(HS_NoopCmd, 1);
+}
+
+void HS_AppPipe_Test_Reset(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_RESET_CC, sizeof(UT_CmdBuf.ResetCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_ResetCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_RESET_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_ResetCmd, 1);
+}
+
+void HS_AppPipe_Test_EnableAppMon(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_APP_MON_CC, sizeof(UT_CmdBuf.EnableAppMonCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_EnableAppMonCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_APP_MON_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_EnableAppMonCmd, 1);
+}
+
+void HS_AppPipe_Test_DisableAppMon(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_APP_MON_CC,
+                              sizeof(UT_CmdBuf.DisableAppMonCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_DisableAppMonCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_APP_MON_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_DisableAppMonCmd, 1);
+}
+
+void HS_AppPipe_Test_EnableEventMon(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_EVENT_MON_CC,
+                              sizeof(UT_CmdBuf.EnableEventMonCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_EnableEventMonCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_EVENT_MON_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_EnableEventMonCmd, 1);
+}
+
+void HS_AppPipe_Test_DisableEventMon(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_EVENT_MON_CC,
+                              sizeof(UT_CmdBuf.DisableEventMonCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_DisableEventMonCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_EVENT_MON_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_DisableEventMonCmd, 1);
+}
+
+void HS_AppPipe_Test_EnableAliveness(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_ALIVENESS_CC,
+                              sizeof(UT_CmdBuf.EnableAlivenessCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_EnableAlivenessCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_ALIVENESS_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_EnableAlivenessCmd, 1);
+}
+
+void HS_AppPipe_Test_DisableAliveness(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_ALIVENESS_CC,
+                              sizeof(UT_CmdBuf.DisableAlivenessCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_DisableAlivenessCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_ALIVENESS_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_DisableAlivenessCmd, 1);
+}
+
+void HS_AppPipe_Test_ResetResetsPerformed(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_RESET_RESETS_PERFORMED_CC,
+                              sizeof(UT_CmdBuf.ResetResetsPerformedCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_ResetResetsPerformedCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_RESET_RESETS_PERFORMED_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_ResetResetsPerformedCmd, 1);
+}
+
+void HS_AppPipe_Test_SetMaxResets(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_SET_MAX_RESETS_CC, sizeof(UT_CmdBuf.SetMaxResetsCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_SetMaxResetsCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_SET_MAX_RESETS_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_SetMaxResetsCmd, 1);
+}
+
+void HS_AppPipe_Test_EnableCPUHog(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_CPU_HOG_CC, sizeof(UT_CmdBuf.EnableCpuHogCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_EnableCpuHogCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_ENABLE_CPU_HOG_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_EnableCpuHogCmd, 1);
+}
+
+void HS_AppPipe_Test_DisableCPUHog(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_CPU_HOG_CC,
+                              sizeof(UT_CmdBuf.DisableCpuHogCmd));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+    UtAssert_STUB_COUNT(HS_DisableCpuHogCmd, 1);
+
+    /* Now with an invalid size */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), HS_DISABLE_CPU_HOG_CC, 1);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Should NOT have invoked the handler */
+    UtAssert_STUB_COUNT(HS_DisableCpuHogCmd, 1);
+}
+
+void HS_AppPipe_Test_InvalidCC(void)
+{
+    /* Setup for CustomCommands to handle it */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), 99, sizeof(UT_CmdBuf));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_ZERO(HS_AppData.CmdErrCount);
+
+    /* Setup for CustomCommands to NOT handle it */
+    HS_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HS_CMD_MID), 99, sizeof(UT_CmdBuf));
+    UT_SetDefaultReturnValue(UT_KEY(HS_CustomCommands), CFE_STATUS_BAD_COMMAND_CODE);
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT8_EQ(HS_AppData.CmdErrCount, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_CC_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
+void HS_AppPipe_Test_InvalidMID(void)
+{
+    HS_Dispatch_Test_SetupMsg(CFE_SB_INVALID_MSG_ID, HS_NOOP_CC, sizeof(UT_CmdBuf));
+
+    /* Execute the function being tested */
+    HS_AppPipe(&UT_CmdBuf.Buf);
+
+    /* Verify results */
+    UtAssert_UINT8_EQ(HS_AppData.CmdErrCount, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_MID_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
+/*
+ * Register the test cases to execute with the unit test tool
+ */
+void UtTest_Setup(void)
+{
+    UtTest_Add(HS_VerifyMsgLength_Test, HS_Test_Setup, HS_Test_TearDown, "HS_VerifyMsgLength_Test");
+
+    UtTest_Add(HS_AppPipe_Test_SendHK, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_SendHK");
+    UtTest_Add(HS_AppPipe_Test_Noop, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_Noop");
+    UtTest_Add(HS_AppPipe_Test_Reset, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_Reset");
+    UtTest_Add(HS_AppPipe_Test_EnableAppMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableAppMon");
+    UtTest_Add(HS_AppPipe_Test_DisableAppMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableAppMon");
+    UtTest_Add(HS_AppPipe_Test_EnableEventMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableEventMon");
+    UtTest_Add(HS_AppPipe_Test_DisableEventMon, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableEventMon");
+    UtTest_Add(HS_AppPipe_Test_EnableAliveness, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableAliveness");
+    UtTest_Add(HS_AppPipe_Test_DisableAliveness, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableAliveness");
+    UtTest_Add(HS_AppPipe_Test_ResetResetsPerformed, HS_Test_Setup, HS_Test_TearDown,
+               "HS_AppPipe_Test_ResetResetsPerformed");
+    UtTest_Add(HS_AppPipe_Test_SetMaxResets, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_SetMaxResets");
+    UtTest_Add(HS_AppPipe_Test_EnableCPUHog, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_EnableCPUHog");
+    UtTest_Add(HS_AppPipe_Test_DisableCPUHog, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_DisableCPUHog");
+    UtTest_Add(HS_AppPipe_Test_InvalidCC, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_InvalidCC");
+    UtTest_Add(HS_AppPipe_Test_InvalidMID, HS_Test_Setup, HS_Test_TearDown, "HS_AppPipe_Test_InvalidMID");
+}

--- a/unit-test/hs_utils_tests.c
+++ b/unit-test/hs_utils_tests.c
@@ -41,119 +41,6 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-void HS_VerifyMsgLength_Test_Nominal(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    bool              Result;
-
-    /*
-     * The CFE_MSG_GetMsgId() stub uses a data buffer to hold the
-     * message ID values to return.
-     */
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = HS_ENABLE_CPU_HOG_CC;
-    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* Execute the function being tested */
-    Result = HS_VerifyMsgLength(&UT_CmdBuf.Msg, sizeof(HS_EnableCpuHogCmd_t));
-
-    /* Verify results */
-    UtAssert_True(Result == true, "Result == true");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_VerifyMsgLength_Test_LengthErrorHK(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    bool              Result;
-    int32             strCmpResult;
-    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Invalid HK request msg length: ID = 0x%%08lX, CC = %%d, Len = %%d, Expected = %%d");
-
-    /*
-     * The CFE_MSG_GetMsgId() stub uses a data buffer to hold the
-     * message ID values to return.
-     */
-    TestMsgId = CFE_SB_ValueToMsgId(HS_SEND_HK_MID);
-    FcnCode   = 0;
-    MsgSize   = 1;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* Execute the function being tested */
-    Result = HS_VerifyMsgLength(&UT_CmdBuf.Msg, sizeof(HS_SendHkCmd_t));
-
-    /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_HKREQ_LEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
-void HS_VerifyMsgLength_Test_LengthErrorNonHK(void)
-{
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    bool              Result;
-    int32             strCmpResult;
-    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Invalid msg length: ID = 0x%%08lX, CC = %%d, Len = %%d, Expected = %%d");
-
-    /*
-     * The CFE_MSG_GetMsgId() stub uses a data buffer to hold the
-     * message ID values to return.
-     */
-    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
-    FcnCode   = 0;
-    MsgSize   = 1;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
-
-    /* Execute the function being tested */
-    Result = HS_VerifyMsgLength(&UT_CmdBuf.Msg, MsgSize + 1);
-
-    /* Verify results */
-    UtAssert_True(Result == false, "Result == false");
-
-    UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_LEN_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-}
-
 void HS_AMTActionIsValid_Valid(void)
 {
     uint16 Action = (HS_AMT_ACT_LAST_NONMSG + HS_MAX_MSG_ACT_TYPES);
@@ -195,12 +82,6 @@ void HS_EMTActionIsValid_Invalid(void)
  */
 void UtTest_Setup(void)
 {
-    UtTest_Add(HS_VerifyMsgLength_Test_Nominal, HS_Test_Setup, HS_Test_TearDown, "HS_VerifyMsgLength_Test_Nominal");
-    UtTest_Add(HS_VerifyMsgLength_Test_LengthErrorHK, HS_Test_Setup, HS_Test_TearDown,
-               "HS_VerifyMsgLength_Test_LengthErrorHK");
-    UtTest_Add(HS_VerifyMsgLength_Test_LengthErrorNonHK, HS_Test_Setup, HS_Test_TearDown,
-               "HS_VerifyMsgLength_Test_LengthErrorNonHK");
-
     UtTest_Add(HS_AMTActionIsValid_Valid, HS_Test_Setup, HS_Test_TearDown, "HS_AMTActionIsValid_Valid");
 
     UtTest_Add(HS_AMTActionIsValid_Invalid, HS_Test_Setup, HS_Test_TearDown, "HS_AMTActionIsValid_Invalid");

--- a/unit-test/stubs/hs_cmds_stubs.c
+++ b/unit-test/stubs/hs_cmds_stubs.c
@@ -50,18 +50,6 @@ void HS_AppMonStatusRefresh(void)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for HS_AppPipe()
- * ----------------------------------------------------
- */
-void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(HS_AppPipe, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(HS_AppPipe, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for HS_DisableAlivenessCmd()
  * ----------------------------------------------------
  */
@@ -158,18 +146,6 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for HS_HousekeepingReq()
- * ----------------------------------------------------
- */
-void HS_HousekeepingReq(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(HS_HousekeepingReq, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(HS_HousekeepingReq, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for HS_MsgActsStatusRefresh()
  * ----------------------------------------------------
  */
@@ -224,6 +200,18 @@ void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr)
     UT_GenStub_AddParam(HS_ResetResetsPerformedCmd, const CFE_SB_Buffer_t *, BufPtr);
 
     UT_GenStub_Execute(HS_ResetResetsPerformedCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_SendHkCmd()
+ * ----------------------------------------------------
+ */
+void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_SendHkCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_SendHkCmd, Basic, NULL);
 }
 
 /*

--- a/unit-test/stubs/hs_custom_dispatch_stubs.c
+++ b/unit-test/stubs/hs_custom_dispatch_stubs.c
@@ -20,40 +20,24 @@
 /**
  * @file
  *
- * Auto-Generated stub implementations for functions defined in hs_utils header
+ * Auto-Generated stub implementations for functions defined in hs_custom_dispatch header
  */
 
-#include "hs_utils.h"
+#include "hs_custom_dispatch.h"
 #include "utgenstub.h"
 
 /*
  * ----------------------------------------------------
- * Generated stub function for HS_AMTActionIsValid()
+ * Generated stub function for HS_CustomCommands()
  * ----------------------------------------------------
  */
-bool HS_AMTActionIsValid(uint16 ActionType)
+int32 HS_CustomCommands(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(HS_AMTActionIsValid, bool);
+    UT_GenStub_SetupReturnBuffer(HS_CustomCommands, int32);
 
-    UT_GenStub_AddParam(HS_AMTActionIsValid, uint16, ActionType);
+    UT_GenStub_AddParam(HS_CustomCommands, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(HS_AMTActionIsValid, Basic, NULL);
+    UT_GenStub_Execute(HS_CustomCommands, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HS_AMTActionIsValid, bool);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for HS_EMTActionIsValid()
- * ----------------------------------------------------
- */
-bool HS_EMTActionIsValid(uint16 ActionType)
-{
-    UT_GenStub_SetupReturnBuffer(HS_EMTActionIsValid, bool);
-
-    UT_GenStub_AddParam(HS_EMTActionIsValid, uint16, ActionType);
-
-    UT_GenStub_Execute(HS_EMTActionIsValid, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(HS_EMTActionIsValid, bool);
+    return UT_GenStub_GetReturnValue(HS_CustomCommands, int32);
 }

--- a/unit-test/stubs/hs_custom_internal_stubs.c
+++ b/unit-test/stubs/hs_custom_internal_stubs.c
@@ -39,22 +39,6 @@ void HS_CustomCleanup(void)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for HS_CustomCommands()
- * ----------------------------------------------------
- */
-int32 HS_CustomCommands(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_SetupReturnBuffer(HS_CustomCommands, int32);
-
-    UT_GenStub_AddParam(HS_CustomCommands, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(HS_CustomCommands, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(HS_CustomCommands, int32);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for HS_CustomGetUtil()
  * ----------------------------------------------------
  */
@@ -116,6 +100,18 @@ void HS_MarkIdleCallback(void)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for HS_ReportDiagCmd()
+ * ----------------------------------------------------
+ */
+void HS_ReportDiagCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_ReportDiagCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_ReportDiagCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for HS_SetUtilDiagCmd()
  * ----------------------------------------------------
  */
@@ -136,17 +132,6 @@ void HS_SetUtilParamsCmd(const CFE_SB_Buffer_t *BufPtr)
     UT_GenStub_AddParam(HS_SetUtilParamsCmd, const CFE_SB_Buffer_t *, BufPtr);
 
     UT_GenStub_Execute(HS_SetUtilParamsCmd, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for HS_UtilDiagReport()
- * ----------------------------------------------------
- */
-void HS_UtilDiagReport(void)
-{
-
-    UT_GenStub_Execute(HS_UtilDiagReport, Basic, NULL);
 }
 
 /*

--- a/unit-test/stubs/hs_dispatch_stubs.c
+++ b/unit-test/stubs/hs_dispatch_stubs.c
@@ -1,0 +1,212 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in hs_dispatch header
+ */
+
+#include "hs_dispatch.h"
+#include "utgenstub.h"
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_AppPipe()
+ * ----------------------------------------------------
+ */
+void HS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_AppPipe, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_AppPipe, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_DisableAlivenessVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_DisableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_DisableAlivenessVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_DisableAlivenessVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_DisableAppMonVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_DisableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_DisableAppMonVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_DisableAppMonVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_DisableCpuHogVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_DisableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_DisableCpuHogVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_DisableCpuHogVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_DisableEventMonVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_DisableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_DisableEventMonVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_DisableEventMonVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_EnableAlivenessVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_EnableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_EnableAlivenessVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_EnableAlivenessVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_EnableAppMonVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_EnableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_EnableAppMonVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_EnableAppMonVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_EnableCpuHogVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_EnableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_EnableCpuHogVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_EnableCpuHogVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_EnableEventMonVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_EnableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_EnableEventMonVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_EnableEventMonVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_NoopVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_NoopVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_NoopVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_ResetResetsPerformedVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_ResetResetsPerformedVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_ResetResetsPerformedVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_ResetResetsPerformedVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_ResetVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_ResetVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_ResetVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_ResetVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_SendHkVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_SendHkVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_SendHkVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_SetMaxResetsVerifyDispatch()
+ * ----------------------------------------------------
+ */
+void HS_SetMaxResetsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HS_SetMaxResetsVerifyDispatch, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HS_SetMaxResetsVerifyDispatch, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HS_VerifyMsgLength()
+ * ----------------------------------------------------
+ */
+bool HS_VerifyMsgLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
+{
+    UT_GenStub_SetupReturnBuffer(HS_VerifyMsgLength, bool);
+
+    UT_GenStub_AddParam(HS_VerifyMsgLength, const CFE_MSG_Message_t *, MsgPtr);
+    UT_GenStub_AddParam(HS_VerifyMsgLength, size_t, ExpectedLength);
+
+    UT_GenStub_Execute(HS_VerifyMsgLength, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_VerifyMsgLength, bool);
+}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Isolate the message verification and dispatch from the general message processing.  Functions in the "cmds" file now strictly handle the command content, and do not get involved in general validation.

The "Custom" code isolation is also in a separate dispatcher.  There is a separate issue to address this.

Fixes #81

**Testing performed**
Build and run HS and all tests, sanity check results

**Expected behavior changes**
None, better source code organization

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
