### PR TITLE
Fix #96, use non-designated initializer for command header

### DIFF
--- a/fsw/tables/hs_mat.c
+++ b/fsw/tables/hs_mat.c
@@ -72,42 +72,34 @@ HS_MatTableEntry_t HS_Default_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
     /*   0 */
     {.EnableState = HS_MAT_STATE_ENABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd1.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+     .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}},
     /*   1 */
     {.EnableState = HS_MAT_STATE_ENABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd2.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_ES_CMD_MID, HS_MEMBER_SIZE(cmd2), CFE_ES_NOOP_CC, CFE_ES_NOOP_CKSUM)},
+     .HsMsg.cmd2  = {CFE_MSG_CMD_HDR_INIT(CFE_ES_CMD_MID, HS_MEMBER_SIZE(cmd2), CFE_ES_NOOP_CC, CFE_ES_NOOP_CKSUM)}},
     /*   2 */
     {.EnableState = HS_MAT_STATE_DISABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd1.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+     .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}},
     /*   3 */
     {.EnableState = HS_MAT_STATE_DISABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd1.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+     .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}},
     /*   4 */
     {.EnableState = HS_MAT_STATE_DISABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd1.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+     .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}},
     /*   5 */
     {.EnableState = HS_MAT_STATE_DISABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd1.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+     .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}},
     /*   6 */
     {.EnableState = HS_MAT_STATE_DISABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd1.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+     .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}},
     /*   7 */
     {.EnableState = HS_MAT_STATE_DISABLED,
      .Cooldown    = 10,
-     .HsMsg.cmd1.CommandHeader =
-         CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)},
+     .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}}
 
 };


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Do not assume specific member names on structs that are not directly part of the HS app itself.

Fixes #96

**Testing performed**
Build HS MAT table in both environments

**Expected behavior changes**
Better source compatibility, no difference in output

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
