### PR TITLE
Fix #98, use "GENERATED_FILE" option to generate_config_includefile

### DIFF
--- a/mission_build.cmake
+++ b/mission_build.cmake
@@ -46,12 +46,12 @@ endif(CFE_EDS_ENABLED_BUILD)
 foreach(HS_CFGFILE ${HS_MISSION_CONFIG_FILE_LIST})
   get_filename_component(CFGKEY "${HS_CFGFILE}" NAME_WE)
   if (DEFINED HS_CFGFILE_SRC_${CFGKEY})
-    set(DEFAULT_SOURCE "${HS_CFGFILE_SRC_${CFGKEY}}")
+    set(DEFAULT_SOURCE GENERATED_FILE "${HS_CFGFILE_SRC_${CFGKEY}}")
   else()
-    set(DEFAULT_SOURCE "${CMAKE_CURRENT_LIST_DIR}/config/default_${HS_CFGFILE}")
+    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${HS_CFGFILE}")
   endif()
   generate_config_includefile(
     FILE_NAME           "${HS_CFGFILE}"
-    FALLBACK_FILE       ${DEFAULT_SOURCE}
+    ${DEFAULT_SOURCE}
   )
 endforeach()


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
For an EDS build, the include files are generated, and do not yet exist when CMake runs.  The generate script now has more error checking than it used to and now throws an error if the file does not exist.

Use of the GENERATED_FILE flag causes it to bypass the the search/verify and unconditionally link to the file.

Fixes #98

**Testing performed**
Build HS with EDS

**Expected behavior changes**
Build succeeds using EDS-generated headers as it should

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
