### PR TITLE
Fix #100, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/fsw/src/hs_app.c
+++ b/fsw/src/hs_app.c
@@ -54,7 +54,7 @@ HS_AppData_t HS_AppData;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_AppMain(void)
 {
-    int32            Status;
+    CFE_Status_t     Status;
     uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;
     CFE_SB_Buffer_t *BufPtr    = NULL;
 
@@ -199,9 +199,9 @@ void HS_AppMain(void)
 /* HS initialization                                               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HS_AppInit(void)
+CFE_Status_t HS_AppInit(void)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /*
     ** Initialize operating data to default states...
@@ -341,9 +341,9 @@ int32 HS_AppInit(void)
 /* Initialize the software bus interface                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HS_SbInit(void)
+CFE_Status_t HS_SbInit(void)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /* Initialize housekeeping packet  */
     CFE_MSG_Init(CFE_MSG_PTR(HS_AppData.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(HS_HK_TLM_MID),
@@ -415,11 +415,11 @@ int32 HS_SbInit(void)
 /* Initialize the table interface                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HS_TblInit(void)
+CFE_Status_t HS_TblInit(void)
 {
-    uint32 TableSize  = 0;
-    uint32 TableIndex = 0;
-    int32  Status;
+    uint32       TableSize  = 0;
+    uint32       TableIndex = 0;
+    CFE_Status_t Status;
 
     /* Register The HS Applications Monitor Table */
     TableSize = HS_MAX_MONITORED_APPS * sizeof(HS_AMTEntry_t);
@@ -529,11 +529,11 @@ int32 HS_TblInit(void)
 /* Main Processing Loop                                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HS_ProcessMain(void)
+CFE_Status_t HS_ProcessMain(void)
 {
-    int32       Status      = CFE_SUCCESS;
-    const char *AliveString = HS_CPU_ALIVE_STRING;
-    uint32      i           = 0;
+    CFE_Status_t Status      = CFE_SUCCESS;
+    const char * AliveString = HS_CPU_ALIVE_STRING;
+    uint32       i           = 0;
 
     /*
     ** Get Tables
@@ -601,9 +601,9 @@ int32 HS_ProcessMain(void)
 /* Process any Commands and Event Messages received this cycle     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HS_ProcessCommands(void)
+CFE_Status_t HS_ProcessCommands(void)
 {
-    int32            Status = CFE_SUCCESS;
+    CFE_Status_t     Status = CFE_SUCCESS;
     CFE_SB_Buffer_t *BufPtr = NULL;
 
     /*

--- a/fsw/src/hs_app.h
+++ b/fsw/src/hs_app.h
@@ -183,7 +183,7 @@ void HS_AppMain(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 HS_AppInit(void);
+CFE_Status_t HS_AppInit(void);
 
 /**
  * \brief Initialize Software Bus
@@ -198,7 +198,7 @@ int32 HS_AppInit(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 HS_SbInit(void);
+CFE_Status_t HS_SbInit(void);
 
 /**
  * \brief Initialize cFE Table Services
@@ -213,7 +213,7 @@ int32 HS_SbInit(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 HS_TblInit(void);
+CFE_Status_t HS_TblInit(void);
 
 /**
  * \brief Perform Normal Periodic Processing
@@ -230,7 +230,7 @@ int32 HS_TblInit(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 HS_ProcessMain(void);
+CFE_Status_t HS_ProcessMain(void);
 
 /**
  * \brief Process commands received from cFE Software Bus
@@ -245,6 +245,6 @@ int32 HS_ProcessMain(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 HS_ProcessCommands(void);
+CFE_Status_t HS_ProcessCommands(void);
 
 #endif

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -304,7 +304,7 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     /*
     ** Unsubscribe from Event Messages if currently enabled
@@ -430,7 +430,7 @@ void HS_SetMaxResetsCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_AcquirePointers(void)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /*
     ** Release the table (AppMon)

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -45,7 +45,7 @@ void HS_MonitorApplications(void)
 {
     CFE_ES_AppInfo_t AppInfo;
     CFE_ES_AppId_t   AppId = CFE_ES_APPID_UNDEFINED;
-    int32            Status;
+    CFE_Status_t     Status;
     uint32           TableIndex = 0;
     uint16           ActionType;
     uint32           MsgActsIndex = 0;
@@ -222,7 +222,7 @@ void HS_MonitorApplications(void)
 void HS_MonitorEvent(const CFE_EVS_LongEventTlm_t *EventPtr)
 {
     uint32           TableIndex = 0;
-    int32            Status     = CFE_SUCCESS;
+    CFE_Status_t     Status     = CFE_SUCCESS;
     CFE_ES_AppId_t   AppId      = CFE_ES_APPID_UNDEFINED;
     uint16           ActionType;
     uint32           MsgActsIndex = 0;

--- a/fsw/src/hs_sysmon.c
+++ b/fsw/src/hs_sysmon.c
@@ -44,10 +44,10 @@
  * Initialize The System Monitor functions
  * --------------------------------------------------------
  */
-int32 HS_SysMonInit(void)
+CFE_Status_t HS_SysMonInit(void)
 {
     CFE_PSP_IODriver_Location_t Location;
-    int32                       StatusCode;
+    CFE_Status_t                StatusCode;
 
     if (CFE_PSP_IODriver_FindByName(HS_SYSTEM_MONITOR_DEVICE, &HS_AppData.SysMonPspModuleId) != CFE_PSP_SUCCESS)
     {
@@ -134,14 +134,14 @@ void HS_SysMonCleanup(void)
  * Obtain the System CPU utilization information
  * --------------------------------------------------------
  */
-int32 HS_SysMonGetCpuUtilization(void)
+CFE_Status_t HS_SysMonGetCpuUtilization(void)
 {
     const CFE_PSP_IODriver_Location_t Location = {.PspModuleId  = HS_AppData.SysMonPspModuleId,
                                                   .SubsystemId  = HS_AppData.SysMonSubsystemId,
                                                   .SubchannelId = HS_AppData.SysMonSubchannelId};
     CFE_PSP_IODriver_AdcCode_t        Sample   = 0;
     CFE_PSP_IODriver_AnalogRdWr_t     RdWr     = {.NumChannels = 1, .Samples = &Sample};
-    int32                             StatusCode;
+    CFE_Status_t                      StatusCode;
     int32                             Value;
 
     if (HS_AppData.SysMonPspModuleId == 0)

--- a/fsw/src/hs_sysmon.h
+++ b/fsw/src/hs_sysmon.h
@@ -77,6 +77,6 @@ void HS_SysMonCleanup(void);
  *
  *  \return Utilization value as fixed-point integer
  */
-int32 HS_SysMonGetCpuUtilization(void);
+CFE_Status_t HS_SysMonGetCpuUtilization(void);
 
 #endif

--- a/unit-test/hs_app_tests.c
+++ b/unit-test/hs_app_tests.c
@@ -72,7 +72,7 @@ void HS_APP_TEST_CFE_RcvBufferHandler(void *UserObj, UT_EntryKey_t FuncKey, cons
 {
     CFE_SB_Buffer_t **BufPtr = UT_Hook_GetArgValueByName(Context, "BufPtr", CFE_SB_Buffer_t **);
 
-    int32 status;
+    CFE_Status_t status;
     HS_APP_TEST_CFE_SB_RcvMsgHookCount++;
 
     if (HS_APP_TEST_CFE_SB_RcvMsgHookCount % 2 == 1)
@@ -570,7 +570,7 @@ void HS_AppMain_Test_StateDisabled(void)
 
 void HS_AppInit_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     HS_AppData.ServiceWatchdogFlag   = 99;
     HS_AppData.AlivenessCounter      = 99;
@@ -626,9 +626,9 @@ void HS_AppInit_Test_Nominal(void)
 
 void HS_AppInit_Test_EVSRegisterError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedSysLogString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "HS App: Error Registering For Event Services, RC = 0x%%08X\n");
 
@@ -679,7 +679,7 @@ void HS_AppInit_Test_EVSRegisterError(void)
 void HS_AppInit_Test_CorruptCDSResetsPerformed(void)
 {
     HS_AppData_t AppData;
-    int32        Result;
+    CFE_Status_t Result;
     int32        strCmpResult;
     char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
@@ -753,7 +753,7 @@ void HS_AppInit_Test_CorruptCDSResetsPerformed(void)
 void HS_AppInit_Test_CorruptCDSMaxResets(void)
 {
     HS_AppData_t AppData;
-    int32        Result;
+    CFE_Status_t Result;
     int32        strCmpResult;
     char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
@@ -824,7 +824,7 @@ void HS_AppInit_Test_CorruptCDSMaxResets(void)
 void HS_AppInit_Test_CorruptCDSNoEvent(void)
 {
     HS_AppData_t AppData;
-    int32        Result;
+    CFE_Status_t Result;
 
     HS_AppData.ServiceWatchdogFlag   = 99;
     HS_AppData.AlivenessCounter      = 99;
@@ -879,9 +879,9 @@ void HS_AppInit_Test_CorruptCDSNoEvent(void)
 
 void HS_AppInit_Test_RestoreCDSError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Failed to restore data from CDS (Err=0x%%08x), initializing resets data");
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "HS Initialized.  Version %%d.%%d.%%d.%%d");
@@ -932,9 +932,9 @@ void HS_AppInit_Test_RestoreCDSError(void)
 
 void HS_AppInit_Test_DisableSavingToCDS(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "HS Initialized.  Version %%d.%%d.%%d.%%d");
 
     HS_AppData.ServiceWatchdogFlag   = 99;
@@ -987,9 +987,9 @@ void HS_AppInit_Test_DisableSavingToCDS(void)
 
 void HS_AppInit_Test_SBInitError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Creating SB Command Pipe,RC=0x%%08X");
 
     HS_AppData.ServiceWatchdogFlag   = 99;
@@ -1044,9 +1044,9 @@ void HS_AppInit_Test_SBInitError(void)
 
 void HS_AppInit_Test_TblInitError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Registering AppMon Table,RC=0x%%08X");
 
     HS_AppData.ServiceWatchdogFlag   = 99;
@@ -1385,7 +1385,7 @@ void HS_SbInit_Test_SubscribeWakeupError(void)
 
 void HS_TblInit_Test_Nominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Same return value as default, but bypasses default hook function to make test easier to write */
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Load), CFE_SUCCESS);
@@ -1404,9 +1404,9 @@ void HS_TblInit_Test_Nominal(void)
 
 void HS_TblInit_Test_RegisterAppMonTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Registering AppMon Table,RC=0x%%08X");
 
     /* Set CFE_TBL_Register to return -1 on first call, to generate error HS_AMT_REG_ERR_EID */
@@ -1437,9 +1437,9 @@ void HS_TblInit_Test_RegisterAppMonTableError(void)
 
 void HS_TblInit_Test_RegisterEventMonTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Registering EventMon Table,RC=0x%%08X");
 
     /* Set CFE_TBL_Register to return -1 on second call, to generate error HS_EMT_REG_ERR_EID */
@@ -1470,9 +1470,9 @@ void HS_TblInit_Test_RegisterEventMonTableError(void)
 
 void HS_TblInit_Test_RegisterMsgActsTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Registering MsgActs Table,RC=0x%%08X");
 
     /* Set CFE_TBL_Register to return -1 on third call, to generate error HS_MAT_REG_ERR_EID */
@@ -1503,9 +1503,9 @@ void HS_TblInit_Test_RegisterMsgActsTableError(void)
 
 void HS_TblInit_Test_RegisterExeCountTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Registering ExeCount Table,RC=0x%%08X");
 
     /* Set CFE_TBL_Register to return -1 on fourth call, to generate error HS_XCT_REG_ERR_EID */
@@ -1536,9 +1536,9 @@ void HS_TblInit_Test_RegisterExeCountTableError(void)
 
 void HS_TblInit_Test_LoadExeCountTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Loading ExeCount Table,RC=0x%%08X");
 
     /* Set CFE_TBL_Load to fail on first call, to generate error HS_XCT_LD_ERR_EID */
@@ -1568,9 +1568,9 @@ void HS_TblInit_Test_LoadExeCountTableError(void)
 
 void HS_TblInit_Test_LoadAppMonTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Loading AppMon Table,RC=0x%%08X");
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Application Monitoring Disabled due to Table Load Failure");
@@ -1613,9 +1613,9 @@ void HS_TblInit_Test_LoadAppMonTableError(void)
 
 void HS_TblInit_Test_LoadEventMonTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Loading EventMon Table,RC=0x%%08X");
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Event Monitoring Disabled due to Table Load Failure");
@@ -1658,9 +1658,9 @@ void HS_TblInit_Test_LoadEventMonTableError(void)
 
 void HS_TblInit_Test_LoadMsgActsTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Loading MsgActs Table,RC=0x%%08X");
 
     /* Set CFE_TBL_Load to fail on fourth call, to generate error HS_MAT_LD_ERR_EID */
@@ -1691,7 +1691,7 @@ void HS_TblInit_Test_LoadMsgActsTableError(void)
 
 void HS_ProcessMain_Test(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     HS_AMTEntry_t AMTable;
 
@@ -1737,7 +1737,7 @@ void HS_ProcessMain_Test(void)
 
 void HS_ProcessMain_Test_MonStateDisabled(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     HS_AMTEntry_t AMTable;
 
@@ -1783,7 +1783,7 @@ void HS_ProcessMain_Test_MonStateDisabled(void)
 
 void HS_ProcessMain_Test_AlivenessDisabled(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     HS_AMTEntry_t AMTable;
 
@@ -1828,7 +1828,7 @@ void HS_ProcessMain_Test_AlivenessDisabled(void)
 
 void HS_ProcessMain_Test_WatchdogDisabled(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     HS_AMTEntry_t AMTable;
 
@@ -1876,7 +1876,7 @@ void HS_ProcessMain_Test_WatchdogDisabled(void)
 
 void HS_ProcessCommands_Test(void)
 {
-    int32         Result;
+    CFE_Status_t  Result;
     uint32        i;
     uint8         call_count_CFE_SB_ReceiveBuffer = 0;
     uint8         call_count_HS_AppPipe           = 0;
@@ -1937,7 +1937,7 @@ void HS_ProcessCommands_Test(void)
 
 void HS_ProcessCommands_Test_NullMsgPtr(void)
 {
-    int32         Result;
+    CFE_Status_t  Result;
     uint32        i;
     uint8         call_count_CFE_SB_ReceiveBuffer = 0;
     uint8         call_count_HS_AppPipe           = 0;

--- a/unit-test/stubs/hs_app_stubs.c
+++ b/unit-test/stubs/hs_app_stubs.c
@@ -31,13 +31,13 @@
  * Generated stub function for HS_AppInit()
  * ----------------------------------------------------
  */
-int32 HS_AppInit(void)
+CFE_Status_t HS_AppInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(HS_AppInit, int32);
+    UT_GenStub_SetupReturnBuffer(HS_AppInit, CFE_Status_t);
 
     UT_GenStub_Execute(HS_AppInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HS_AppInit, int32);
+    return UT_GenStub_GetReturnValue(HS_AppInit, CFE_Status_t);
 }
 
 /*
@@ -56,13 +56,13 @@ void HS_AppMain(void)
  * Generated stub function for HS_ProcessCommands()
  * ----------------------------------------------------
  */
-int32 HS_ProcessCommands(void)
+CFE_Status_t HS_ProcessCommands(void)
 {
-    UT_GenStub_SetupReturnBuffer(HS_ProcessCommands, int32);
+    UT_GenStub_SetupReturnBuffer(HS_ProcessCommands, CFE_Status_t);
 
     UT_GenStub_Execute(HS_ProcessCommands, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HS_ProcessCommands, int32);
+    return UT_GenStub_GetReturnValue(HS_ProcessCommands, CFE_Status_t);
 }
 
 /*
@@ -70,13 +70,13 @@ int32 HS_ProcessCommands(void)
  * Generated stub function for HS_ProcessMain()
  * ----------------------------------------------------
  */
-int32 HS_ProcessMain(void)
+CFE_Status_t HS_ProcessMain(void)
 {
-    UT_GenStub_SetupReturnBuffer(HS_ProcessMain, int32);
+    UT_GenStub_SetupReturnBuffer(HS_ProcessMain, CFE_Status_t);
 
     UT_GenStub_Execute(HS_ProcessMain, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HS_ProcessMain, int32);
+    return UT_GenStub_GetReturnValue(HS_ProcessMain, CFE_Status_t);
 }
 
 /*
@@ -84,13 +84,13 @@ int32 HS_ProcessMain(void)
  * Generated stub function for HS_SbInit()
  * ----------------------------------------------------
  */
-int32 HS_SbInit(void)
+CFE_Status_t HS_SbInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(HS_SbInit, int32);
+    UT_GenStub_SetupReturnBuffer(HS_SbInit, CFE_Status_t);
 
     UT_GenStub_Execute(HS_SbInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HS_SbInit, int32);
+    return UT_GenStub_GetReturnValue(HS_SbInit, CFE_Status_t);
 }
 
 /*
@@ -98,11 +98,11 @@ int32 HS_SbInit(void)
  * Generated stub function for HS_TblInit()
  * ----------------------------------------------------
  */
-int32 HS_TblInit(void)
+CFE_Status_t HS_TblInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(HS_TblInit, int32);
+    UT_GenStub_SetupReturnBuffer(HS_TblInit, CFE_Status_t);
 
     UT_GenStub_Execute(HS_TblInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HS_TblInit, int32);
+    return UT_GenStub_GetReturnValue(HS_TblInit, CFE_Status_t);
 }

--- a/unit-test/stubs/hs_sysmon_stubs.c
+++ b/unit-test/stubs/hs_sysmon_stubs.c
@@ -42,13 +42,13 @@ void HS_SysMonCleanup(void)
  * Generated stub function for HS_SysMonGetCpuUtilization()
  * ----------------------------------------------------
  */
-int32 HS_SysMonGetCpuUtilization(void)
+CFE_Status_t HS_SysMonGetCpuUtilization(void)
 {
-    UT_GenStub_SetupReturnBuffer(HS_SysMonGetCpuUtilization, int32);
+    UT_GenStub_SetupReturnBuffer(HS_SysMonGetCpuUtilization, CFE_Status_t);
 
     UT_GenStub_Execute(HS_SysMonGetCpuUtilization, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HS_SysMonGetCpuUtilization, int32);
+    return UT_GenStub_GetReturnValue(HS_SysMonGetCpuUtilization, CFE_Status_t);
 }
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #100
  - most `int32` return codes converted over to `CFE_Status_t`
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt