### PR TITLE
Fix #110, adds #include hs_platform_cfg.h

### DIFF
--- a/fsw/src/hs_sysmon.c
+++ b/fsw/src/hs_sysmon.c
@@ -30,7 +30,7 @@
 ** Includes
 *************************************************************************/
 #include "hs_sysmon.h"
-#include "hs_internal_cfg.h"
+#include "hs_platform_cfg.h"
 #include "hs_app.h"
 
 #include "cfe.h"


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #110 
Replaces the `#include hs_internal_cfg.h` with `#include hs_platform_cfg.h` such that hs_sysmon.c is backward compatible with the original hs_platform_cfg.h file.

**Testing performed**
local machine build app and lcov

**Expected behavior changes**
No impact or behavior

**System(s) tested on**
 - OS: Ubuntu 20.04

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
