### PR TITLE
Fix #114, clean up dispatch logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,20 @@ project(CFS_HS C)
 set(APP_SRC_FILES
   fsw/src/hs_monitors.c
   fsw/src/hs_utils.c
-  fsw/src/hs_dispatch.c
   fsw/src/hs_sysmon.c
   fsw/src/hs_app.c
   fsw/src/hs_cmds.c
 )
+
+if (CFE_EDS_ENABLED_BUILD)
+  list(APPEND APP_SRC_FILES
+    fsw/src/hs_eds_dispatch.c
+  )
+else()
+  list(APPEND APP_SRC_FILES
+    fsw/src/hs_dispatch.c
+  )
+endif()
 
 # Create the app module
 add_cfe_app(hs ${APP_SRC_FILES})

--- a/arch_build.cmake
+++ b/arch_build.cmake
@@ -15,25 +15,18 @@ set(HS_PLATFORM_CONFIG_FILE_LIST
   hs_platform_cfg.h
 )
 
-if (CFE_EDS_ENABLED_BUILD)
-
-  # In an EDS-based build, msgids come generated from the EDS tool
-  set(HS_CFGFILE_SRC_hs_msgids "${CMAKE_CURRENT_LIST_DIR}/config/hs_eds_msg_topicids.h")
-
-endif(CFE_EDS_ENABLED_BUILD)
-
 # Create wrappers around the all the config header files
 # This makes them individually overridable by the missions, without modifying
 # the distribution default copies
 foreach(HS_CFGFILE ${HS_PLATFORM_CONFIG_FILE_LIST})
   get_filename_component(CFGKEY "${HS_CFGFILE}" NAME_WE)
   if (DEFINED HS_CFGFILE_SRC_${CFGKEY})
-    set(DEFAULT_SOURCE "${HS_CFGFILE_SRC_${CFGKEY}}")
+    set(DEFAULT_SOURCE GENERATED_FILE "${HS_CFGFILE_SRC_${CFGKEY}}")
   else()
-    set(DEFAULT_SOURCE "${CMAKE_CURRENT_LIST_DIR}/config/default_${HS_CFGFILE}")
+    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${HS_CFGFILE}")
   endif()
   generate_config_includefile(
     FILE_NAME           "${HS_CFGFILE}"
-    FALLBACK_FILE       ${DEFAULT_SOURCE}
+    ${DEFAULT_SOURCE}
   )
 endforeach()

--- a/config/default_hs_internal_cfg.h
+++ b/config/default_hs_internal_cfg.h
@@ -39,23 +39,6 @@
  */
 
 /**
- * \brief Application Name
- *
- *  \par Description:
- *       This definition must match the name used at startup by the cFE
- *       Executive Services when creating the HS application.  Note that
- *       application names are also an argument to certain cFE commands.
- *       For example, the application name is needed to access tables
- *       via cFE Table Services commands.
- *
- *  \par Limits:
- *       HS requires that this name be defined, but otherwise places
- *       no limits on the definition.  Refer to CFE Executive Services
- *       for specific information on limits related to application names.
- */
-#define HS_APP_NAME "HS"
-
-/**
  * \brief Watchdog Timeout Value
  *
  *  \par Description:

--- a/config/default_hs_mission_cfg.h
+++ b/config/default_hs_mission_cfg.h
@@ -34,4 +34,21 @@
 
 #include "hs_interface_cfg.h"
 
+/**
+ * \brief Application Name
+ *
+ *  \par Description:
+ *       This definition must match the name used at startup by the cFE
+ *       Executive Services when creating the HS application.  Note that
+ *       application names are also an argument to certain cFE commands.
+ *       For example, the application name is needed to access tables
+ *       via cFE Table Services commands.
+ *
+ *  \par Limits:
+ *       HS requires that this name be defined, but otherwise places
+ *       no limits on the definition.  Refer to CFE Executive Services
+ *       for specific information on limits related to application names.
+ */
+#define HS_APP_NAME "HS"
+
 #endif

--- a/config/default_hs_topicids.h
+++ b/config/default_hs_topicids.h
@@ -19,37 +19,14 @@
 
 /**
  * @file
- *   CFS Health and Safety (HS) Application Message IDs
+ *   CFS Health and Safety (HS) Application Topic IDs
  */
-#ifndef HS_MSGIDS_H
-#define HS_MSGIDS_H
+#ifndef HS_TOPICIDS_H
+#define HS_TOPICIDS_H
 
-#include "cfe_msgids.h"
-
-/**
- * \defgroup cfshscmdmid CFS Health and Safety Command Message IDs
- * \{
- */
-
-/** \brief Msg ID for cmds to HS */
-#define HS_CMD_MID CFE_PLATFORM_CMD_TOPICID_TO_MID(CFE_MISSION_HS_CMD_TOPICID)
-
-/** \brief Msg ID to request HS housekeeping */
-#define HS_SEND_HK_MID CFE_PLATFORM_CMD_TOPICID_TO_MID(CFE_MISSION_HS_SEND_HK_TOPICID)
-
-/** \brief Msg ID to wake up HS */
-#define HS_WAKEUP_MID CFE_PLATFORM_CMD_TOPICID_TO_MID(CFE_MISSION_HS_WAKEUP_TOPICID)
-
-/**\}*/
-
-/**
- * \defgroup cfshstlmmid CFS Health and Safety Telemetry Message IDs
- * \{
- */
-
-/** \brief HS Housekeeping Telemetry */
-#define HS_HK_TLM_MID CFE_PLATFORM_TLM_TOPICID_TO_MID(CFE_MISSION_HS_HK_TLM_TOPICID)
-
-/**\}*/
+#define CFE_MISSION_HS_CMD_TOPICID     0xAE /**< \brief Msg ID for cmds to HS                */
+#define CFE_MISSION_HS_SEND_HK_TOPICID 0xAF /**< \brief Msg ID to request HS housekeeping    */
+#define CFE_MISSION_HS_WAKEUP_TOPICID  0xB0 /**< \brief Msg ID to wake up HS                 */
+#define CFE_MISSION_HS_HK_TLM_TOPICID  0xAD /**< \brief HS Housekeeping Telemetry            */
 
 #endif

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -46,7 +46,7 @@
 /* Housekeeping request                                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
 {
     CFE_ES_AppId_t AppId = CFE_ES_APPID_UNDEFINED;
 
@@ -184,6 +184,8 @@ void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
     */
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(HS_AppData.HkPacket.TelemetryHeader));
     CFE_SB_TransmitMsg(CFE_MSG_PTR(HS_AppData.HkPacket.TelemetryHeader), true);
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -191,12 +193,14 @@ void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Noop command                                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_NoopCmd(const HS_NoopCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
 
     CFE_EVS_SendEvent(HS_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command: Version %d.%d.%d.%d",
                       HS_MAJOR_VERSION, HS_MINOR_VERSION, HS_REVISION, HS_MISSION_REV);
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -204,11 +208,12 @@ void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Reset counters command                                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_ResetCmd(const HS_ResetCmd_t *BufPtr)
 {
     HS_ResetCounters();
 
     CFE_EVS_SendEvent(HS_RESET_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -229,12 +234,13 @@ void HS_ResetCounters(void)
 /* Enable applications monitor command                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableAppMonCmd(const HS_EnableAppMonCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
     HS_AppMonStatusRefresh();
     HS_AppData.CurrentAppMonState = HS_STATE_ENABLED;
     CFE_EVS_SendEvent(HS_ENABLE_APPMON_DBG_EID, CFE_EVS_EventType_DEBUG, "Application Monitoring Enabled");
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -242,11 +248,12 @@ void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Disable applications monitor command                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableAppMonCmd(const HS_DisableAppMonCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
     HS_AppData.CurrentAppMonState = HS_STATE_DISABLED;
     CFE_EVS_SendEvent(HS_DISABLE_APPMON_DBG_EID, CFE_EVS_EventType_DEBUG, "Application Monitoring Disabled");
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -254,7 +261,7 @@ void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Enable events monitor command                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableEventMonCmd(const HS_EnableEventMonCmd_t *BufPtr)
 {
     CFE_Status_t Status = CFE_SUCCESS;
 
@@ -295,6 +302,8 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
     {
         HS_AppData.CmdErrCount++;
     }
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -302,7 +311,7 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Disable event monitor command                                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableEventMonCmd(const HS_DisableEventMonCmd_t *BufPtr)
 {
     CFE_Status_t Status = CFE_SUCCESS;
 
@@ -342,6 +351,8 @@ void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
     {
         HS_AppData.CmdErrCount++;
     }
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -349,11 +360,13 @@ void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Enable aliveness indicator command                              */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableAlivenessCmd(const HS_EnableAlivenessCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
     HS_AppData.CurrentAlivenessState = HS_STATE_ENABLED;
     CFE_EVS_SendEvent(HS_ENABLE_ALIVENESS_DBG_EID, CFE_EVS_EventType_DEBUG, "Aliveness Indicator Enabled");
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -361,11 +374,13 @@ void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Disable aliveness indicator command                             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableAlivenessCmd(const HS_DisableAlivenessCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
     HS_AppData.CurrentAlivenessState = HS_STATE_DISABLED;
     CFE_EVS_SendEvent(HS_DISABLE_ALIVENESS_DBG_EID, CFE_EVS_EventType_DEBUG, "Aliveness Indicator Disabled");
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -373,11 +388,13 @@ void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Enable cpu hogging indicator command                            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableCpuHogCmd(const HS_EnableCpuHogCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
     HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
     CFE_EVS_SendEvent(HS_ENABLE_CPUHOG_DBG_EID, CFE_EVS_EventType_DEBUG, "CPU Hogging Indicator Enabled");
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -385,11 +402,13 @@ void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Disable cpu hogging indicator command                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableCpuHogCmd(const HS_DisableCpuHogCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
     HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
     CFE_EVS_SendEvent(HS_DISABLE_CPUHOG_DBG_EID, CFE_EVS_EventType_DEBUG, "CPU Hogging Indicator Disabled");
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -397,12 +416,14 @@ void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Reset processor resets performed count command                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_ResetResetsPerformedCmd(const HS_ResetResetsPerformedCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
     HS_SetCDSData(0, HS_AppData.CDSData.MaxResets);
     CFE_EVS_SendEvent(HS_RESET_RESETS_DBG_EID, CFE_EVS_EventType_DEBUG,
                       "Processor Resets Performed by HS Counter has been Reset");
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -410,7 +431,7 @@ void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr)
 /* Set max processor resets command                                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_SetMaxResetsCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_SetMaxResetsCmd(const HS_SetMaxResetsCmd_t *BufPtr)
 {
     const HS_SetMaxResets_Payload_t *CmdPtr;
 
@@ -421,6 +442,8 @@ void HS_SetMaxResetsCmd(const CFE_SB_Buffer_t *BufPtr)
 
     CFE_EVS_SendEvent(HS_SET_MAX_RESETS_DBG_EID, CFE_EVS_EventType_DEBUG,
                       "Max Resets Performable by HS has been set to %d", HS_AppData.CDSData.MaxResets);
+
+    return CFE_SUCCESS;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/hs_cmds.h
+++ b/fsw/src/hs_cmds.h
@@ -28,7 +28,8 @@
 /*************************************************************************
  * Includes
  ************************************************************************/
-#include "cfe.h"
+#include "cfe_error.h"
+#include "hs_msg.h"
 
 /*************************************************************************
  * Exported Functions
@@ -74,7 +75,7 @@ void HS_AcquirePointers(void);
  *
  *  \param[in] BufPtr Pointer to Software Bus buffer
  */
-void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr);
 
 /**
  * \brief Noop command
@@ -89,7 +90,7 @@ void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_NOOP_CC
  */
-void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_NoopCmd(const HS_NoopCmd_t *BufPtr);
 
 /**
  * \brief Reset counters command
@@ -107,7 +108,7 @@ void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_RESET_CC
  */
-void HS_ResetCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_ResetCmd(const HS_ResetCmd_t *BufPtr);
 
 /**
  * \brief Process an enable critical applications monitor command
@@ -122,7 +123,7 @@ void HS_ResetCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_ENABLE_APP_MON_CC
  */
-void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_EnableAppMonCmd(const HS_EnableAppMonCmd_t *BufPtr);
 
 /**
  * \brief Process a disable critical applications monitor command
@@ -137,7 +138,7 @@ void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_DISABLE_APP_MON_CC
  */
-void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_DisableAppMonCmd(const HS_DisableAppMonCmd_t *BufPtr);
 
 /**
  * \brief Process an enable critical events monitor command
@@ -152,7 +153,7 @@ void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_ENABLE_EVENT_MON_CC
  */
-void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_EnableEventMonCmd(const HS_EnableEventMonCmd_t *BufPtr);
 
 /**
  * \brief Process a disable critical events monitor command
@@ -167,7 +168,7 @@ void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_DISABLE_EVENT_MON_CC
  */
-void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_DisableEventMonCmd(const HS_DisableEventMonCmd_t *BufPtr);
 
 /**
  * \brief Process an enable aliveness indicator command
@@ -182,7 +183,7 @@ void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_ENABLE_ALIVENESS_CC
  */
-void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_EnableAlivenessCmd(const HS_EnableAlivenessCmd_t *BufPtr);
 
 /**
  * \brief Process a disable aliveness indicator command
@@ -197,7 +198,7 @@ void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_DISABLE_ALIVENESS_CC
  */
-void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_DisableAlivenessCmd(const HS_DisableAlivenessCmd_t *BufPtr);
 
 /**
  * \brief Process an enable CPU Hogging indicator command
@@ -212,7 +213,7 @@ void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_ENABLE_CPU_HOG_CC
  */
-void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_EnableCpuHogCmd(const HS_EnableCpuHogCmd_t *BufPtr);
 
 /**
  * \brief Process a disable CPU Hogging indicator command
@@ -227,7 +228,7 @@ void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_DISABLE_CPU_HOG_CC
  */
-void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_DisableCpuHogCmd(const HS_DisableCpuHogCmd_t *BufPtr);
 
 /**
  * \brief Process a reset resets performed command
@@ -242,7 +243,7 @@ void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_SET_MAX_RESETS_CC
  */
-void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_ResetResetsPerformedCmd(const HS_ResetResetsPerformedCmd_t *BufPtr);
 
 /**
  * \brief Process a set max resets command
@@ -257,7 +258,7 @@ void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \sa #HS_RESET_RESETS_PERFORMED_CC
  */
-void HS_SetMaxResetsCmd(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t HS_SetMaxResetsCmd(const HS_SetMaxResetsCmd_t *BufPtr);
 
 /**
  * \brief Refresh Critical Applications Monitor Status

--- a/fsw/src/hs_dispatch.c
+++ b/fsw/src/hs_dispatch.c
@@ -199,7 +199,7 @@ void HS_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_SendHkCmd(BufPtr);
+        HS_SendHkCmd((const HS_SendHkCmd_t *)BufPtr);
     }
 }
 
@@ -217,7 +217,7 @@ void HS_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_NoopCmd(BufPtr);
+        HS_NoopCmd((const HS_NoopCmd_t *)BufPtr);
     }
 }
 
@@ -235,7 +235,7 @@ void HS_ResetVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_ResetCmd(BufPtr);
+        HS_ResetCmd((const HS_ResetCmd_t *)BufPtr);
     }
 }
 
@@ -253,7 +253,7 @@ void HS_EnableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_EnableAppMonCmd(BufPtr);
+        HS_EnableAppMonCmd((const HS_EnableAppMonCmd_t *)BufPtr);
     }
 }
 
@@ -271,7 +271,7 @@ void HS_DisableAppMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_DisableAppMonCmd(BufPtr);
+        HS_DisableAppMonCmd((const HS_DisableAppMonCmd_t *)BufPtr);
     }
 }
 
@@ -289,7 +289,7 @@ void HS_EnableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_EnableEventMonCmd(BufPtr);
+        HS_EnableEventMonCmd((const HS_EnableEventMonCmd_t *)BufPtr);
     }
 }
 
@@ -307,7 +307,7 @@ void HS_DisableEventMonVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_DisableEventMonCmd(BufPtr);
+        HS_DisableEventMonCmd((const HS_DisableEventMonCmd_t *)BufPtr);
     }
 }
 
@@ -325,7 +325,7 @@ void HS_EnableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_EnableAlivenessCmd(BufPtr);
+        HS_EnableAlivenessCmd((const HS_EnableAlivenessCmd_t *)BufPtr);
     }
 }
 
@@ -343,7 +343,7 @@ void HS_DisableAlivenessVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_DisableAlivenessCmd(BufPtr);
+        HS_DisableAlivenessCmd((const HS_DisableAlivenessCmd_t *)BufPtr);
     }
 }
 
@@ -361,7 +361,7 @@ void HS_EnableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_EnableCpuHogCmd(BufPtr);
+        HS_EnableCpuHogCmd((const HS_EnableCpuHogCmd_t *)BufPtr);
     }
 }
 
@@ -379,7 +379,7 @@ void HS_DisableCpuHogVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_DisableCpuHogCmd(BufPtr);
+        HS_DisableCpuHogCmd((const HS_DisableCpuHogCmd_t *)BufPtr);
     }
 }
 
@@ -397,7 +397,7 @@ void HS_ResetResetsPerformedVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_ResetResetsPerformedCmd(BufPtr);
+        HS_ResetResetsPerformedCmd((const HS_ResetResetsPerformedCmd_t *)BufPtr);
     }
 }
 
@@ -415,6 +415,6 @@ void HS_SetMaxResetsVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
     */
     if (HS_VerifyMsgLength(&BufPtr->Msg, ExpectedLength))
     {
-        HS_SetMaxResetsCmd(BufPtr);
+        HS_SetMaxResetsCmd((const HS_SetMaxResetsCmd_t *)BufPtr);
     }
 }

--- a/fsw/src/hs_eds_dispatch.c
+++ b/fsw/src/hs_eds_dispatch.c
@@ -1,0 +1,126 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,920-1, and identified as “Core Flight
+ * System (cFS) Health & Safety (HS) Application version 2.4.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   CFS Health and Safety (HS) command handling routines
+ */
+
+/************************************************************************
+** Includes
+*************************************************************************/
+#include "hs_app.h"
+#include "hs_cmds.h"
+#include "hs_msgids.h"
+#include "hs_msgdefs.h"
+#include "hs_eventids.h"
+#include "hs_dispatch.h"
+#include "hs_version.h"
+
+#include "hs_eds_dispatcher.h"
+#include "hs_eds_dictionary.h"
+
+/* clang-format off */
+/*
+ * Define a lookup table for SAMPLE app command codes
+ */
+static const HS_Application_Component_Telecommand_DispatchTable_t HS_TC_DISPATCH_TABLE =
+{
+    .CMD =
+    {
+        .DisableAlivenessCmd_indication = HS_DisableAlivenessCmd,
+        .DisableAppMonCmd_indication = HS_DisableAppMonCmd,
+        .DisableCpuHogCmd_indication = HS_DisableCpuHogCmd,
+        .DisableEventMonCmd_indication = HS_DisableEventMonCmd,
+        .EnableAlivenessCmd_indication = HS_EnableAlivenessCmd,
+        .EnableAppMonCmd_indication = HS_EnableAppMonCmd,
+        .EnableCpuHogCmd_indication = HS_EnableCpuHogCmd,
+        .EnableEventMonCmd_indication = HS_EnableEventMonCmd,
+        .NoopCmd_indication = HS_NoopCmd,
+        .ResetCmd_indication = HS_ResetCmd,
+        .ResetResetsPerformedCmd_indication = HS_ResetResetsPerformedCmd,
+        .SetMaxResetsCmd_indication = HS_SetMaxResetsCmd,
+    },
+    .SEND_HK =
+    {
+        .indication = HS_SendHkCmd
+    }
+};
+/* clang-format on */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
+/*                                                                            */
+/*  Purpose:                                                                  */
+/*     This routine will process any packet that is received on the SAMPLE    */
+/*     command pipe.                                                          */
+/*                                                                            */
+/* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
+void HS_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
+{
+    CFE_Status_t      Status;
+    CFE_SB_MsgId_t    MsgId;
+    CFE_MSG_Size_t    MsgSize;
+    CFE_MSG_FcnCode_t MsgFc;
+
+    Status = HS_Application_Component_Telecommand_Dispatch(CFE_SB_Telecommand_indication_Command_ID, SBBufPtr,
+                                                           &HS_TC_DISPATCH_TABLE);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MsgId);
+        CFE_MSG_GetSize(&SBBufPtr->Msg, &MsgSize);
+        CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &MsgFc);
+
+        if (Status == CFE_STATUS_UNKNOWN_MSG_ID)
+        {
+            CFE_EVS_SendEvent(HS_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command pipe message ID: 0x%08lX",
+                              (unsigned long)CFE_SB_MsgIdToValue(MsgId));
+            HS_AppData.CmdErrCount++;
+        }
+        else if (Status == CFE_STATUS_WRONG_MSG_LENGTH)
+        {
+            if (CFE_SB_MsgIdToValue(MsgId) == HS_SEND_HK_MID)
+            {
+                /*
+                ** For a bad HK request, just send the event. We only increment
+                ** the error counter for ground commands and not internal messages.
+                */
+                CFE_EVS_SendEvent(HS_HKREQ_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Invalid HK request msg length: ID = 0x%08lX, CC = %d, Len = %d",
+                                  (unsigned long)CFE_SB_MsgIdToValue(MsgId), (int)MsgFc, (int)MsgSize);
+            }
+            else
+            {
+                /*
+                ** All other cases, increment error counter
+                */
+                CFE_EVS_SendEvent(HS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %d",
+                                  (unsigned long)CFE_SB_MsgIdToValue(MsgId), (int)MsgFc, (int)MsgSize);
+                HS_AppData.CmdErrCount++;
+            }
+        }
+        else
+        {
+            CFE_EVS_SendEvent(HS_CC_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command code: ID = 0x%08lX, CC = %d",
+                              (unsigned long)CFE_SB_MsgIdToValue(MsgId), (int)MsgFc);
+            HS_AppData.CmdErrCount++;
+        }
+    }
+}

--- a/fsw/tables/hs_amt.c
+++ b/fsw/tables/hs_amt.c
@@ -26,7 +26,7 @@
 ** Includes
 *************************************************************************/
 #include "cfe.h"
-#include "hs_platform_cfg.h"
+#include "hs_mission_cfg.h"
 #include "hs_tbl.h"
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"

--- a/fsw/tables/hs_emt.c
+++ b/fsw/tables/hs_emt.c
@@ -26,7 +26,7 @@
 ** Includes
 *************************************************************************/
 #include "cfe.h"
-#include "hs_platform_cfg.h"
+#include "hs_mission_cfg.h"
 #include "hs_tbl.h"
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"

--- a/fsw/tables/hs_mat.c
+++ b/fsw/tables/hs_mat.c
@@ -26,7 +26,7 @@
 ** Includes
 *************************************************************************/
 #include "cfe.h"
-#include "hs_platform_cfg.h"
+#include "hs_mission_cfg.h"
 #include "hs_tbl.h"
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"

--- a/fsw/tables/hs_xct.c
+++ b/fsw/tables/hs_xct.c
@@ -26,7 +26,7 @@
 ** Includes
 *************************************************************************/
 #include "cfe.h"
-#include "hs_platform_cfg.h"
+#include "hs_mission_cfg.h"
 #include "hs_tbl.h"
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"

--- a/mission_build.cmake
+++ b/mission_build.cmake
@@ -22,6 +22,7 @@ set(HS_MISSION_CONFIG_FILE_LIST
   hs_tbldefs.h
   hs_tbl.h
   hs_tblstruct.h
+  hs_topicids.h
 )
 
 if (CFE_EDS_ENABLED_BUILD)

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -97,7 +97,7 @@ void HS_SendHkCmd_Test_InvalidEventMon(void)
     }
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -187,7 +187,7 @@ void HS_SendHkCmd_Test_AllFlagsEnabled(void)
     ExpectedStatusFlags |= HS_CDS_IN_USE;
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -285,7 +285,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppMain(void)
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -382,7 +382,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppChild(void)
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -480,7 +480,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError(void)
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -574,7 +574,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetTaskInfo), 1, -1);
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -669,7 +669,7 @@ void HS_SendHkCmd_Test_ResourceTypeDevice(void)
     UT_SetHookFunction(UT_KEY(CFE_ES_GetTaskInfo), HS_CMDS_TEST_CFE_ES_GetTaskInfoHook, &TaskInfo);
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -757,7 +757,7 @@ void HS_SendHkCmd_Test_ResourceTypeISR(void)
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCT_TYPE_ISR;
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -848,7 +848,7 @@ void HS_SendHkCmd_Test_ResourceTypeISRGenCounterError(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_GetGenCounterIDByName), -1);
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -941,7 +941,7 @@ void HS_SendHkCmd_Test_ResourceTypeUnknown(void)
     ExpectedStatusFlags |= HS_CDS_IN_USE;
 
     /* Execute the function being tested */
-    HS_SendHkCmd(&UT_CmdBuf.Buf);
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
 
     /* Verify results */
     PayloadPtr = &HS_AppData.HkPacket.Payload;
@@ -994,7 +994,7 @@ void HS_Noop_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    HS_NoopCmd(&UT_CmdBuf.Buf);
+    HS_NoopCmd(&UT_CmdBuf.NoopCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1029,7 +1029,7 @@ void HS_ResetCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    HS_ResetCmd(&UT_CmdBuf.Buf);
+    HS_ResetCmd(&UT_CmdBuf.ResetCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
@@ -1085,7 +1085,7 @@ void HS_EnableAppMonCmd_Test(void)
     HS_AppData.AMTablePtr = AMTable;
 
     /* Execute the function being tested */
-    HS_EnableAppMonCmd(&UT_CmdBuf.Buf);
+    HS_EnableAppMonCmd(&UT_CmdBuf.EnableAppMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1123,7 +1123,7 @@ void HS_DisableAppMonCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    HS_DisableAppMonCmd(&UT_CmdBuf.Buf);
+    HS_DisableAppMonCmd(&UT_CmdBuf.DisableAppMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1163,7 +1163,7 @@ void HS_EnableEventMonCmd_Test_Disabled(void)
     HS_AppData.CurrentEventMonState = HS_STATE_DISABLED;
 
     /* Execute the function being tested */
-    HS_EnableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_EnableEventMonCmd(&UT_CmdBuf.EnableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1203,7 +1203,7 @@ void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
     HS_AppData.CurrentEventMonState = HS_STATE_ENABLED;
 
     /* Execute the function being tested */
-    HS_EnableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_EnableEventMonCmd(&UT_CmdBuf.EnableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1246,7 +1246,7 @@ void HS_EnableEventMonCmd_Test_SubscribeLongError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 1, -1);
 
     /* Execute the function being tested */
-    HS_EnableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_EnableEventMonCmd(&UT_CmdBuf.EnableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
@@ -1289,7 +1289,7 @@ void HS_EnableEventMonCmd_Test_SubscribeShortError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 2, -1);
 
     /* Execute the function being tested */
-    HS_EnableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_EnableEventMonCmd(&UT_CmdBuf.EnableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
@@ -1329,7 +1329,7 @@ void HS_DisableEventMonCmd_Test_Enabled(void)
     HS_AppData.CurrentEventMonState = HS_STATE_ENABLED;
 
     /* Execute the function being tested */
-    HS_DisableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_DisableEventMonCmd(&UT_CmdBuf.DisableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1369,7 +1369,7 @@ void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
     HS_AppData.CurrentEventMonState = HS_STATE_DISABLED;
 
     /* Execute the function being tested */
-    HS_DisableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_DisableEventMonCmd(&UT_CmdBuf.DisableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1412,7 +1412,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeLongError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Unsubscribe), 1, -1);
 
     /* Execute the function being tested */
-    HS_DisableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_DisableEventMonCmd(&UT_CmdBuf.DisableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
@@ -1455,7 +1455,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeShortError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_Unsubscribe), 2, -1);
 
     /* Execute the function being tested */
-    HS_DisableEventMonCmd(&UT_CmdBuf.Buf);
+    HS_DisableEventMonCmd(&UT_CmdBuf.DisableEventMonCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdErrCount == 1, "HS_AppData.CmdErrCount == 1");
@@ -1495,7 +1495,7 @@ void HS_EnableAlivenessCmd_Test(void)
     HS_AppData.CurrentAlivenessState = HS_STATE_DISABLED;
 
     /* Execute the function being tested */
-    HS_EnableAlivenessCmd(&UT_CmdBuf.Buf);
+    HS_EnableAlivenessCmd(&UT_CmdBuf.EnableAlivenessCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1535,7 +1535,7 @@ void HS_DisableAlivenessCmd_Test(void)
     HS_AppData.CurrentAlivenessState = HS_STATE_ENABLED;
 
     /* Execute the function being tested */
-    HS_DisableAlivenessCmd(&UT_CmdBuf.Buf);
+    HS_DisableAlivenessCmd(&UT_CmdBuf.DisableAlivenessCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1575,7 +1575,7 @@ void HS_EnableCpuHogCmd_Test(void)
     HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
 
     /* Execute the function being tested */
-    HS_EnableCpuHogCmd(&UT_CmdBuf.Buf);
+    HS_EnableCpuHogCmd(&UT_CmdBuf.EnableCpuHogCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1615,7 +1615,7 @@ void HS_DisableCpuHogCmd_Test(void)
     HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
 
     /* Execute the function being tested */
-    HS_DisableCpuHogCmd(&UT_CmdBuf.Buf);
+    HS_DisableCpuHogCmd(&UT_CmdBuf.DisableCpuHogCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1654,7 +1654,7 @@ void HS_ResetResetsPerformedCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
     /* Execute the function being tested */
-    HS_ResetResetsPerformedCmd(&UT_CmdBuf.Buf);
+    HS_ResetResetsPerformedCmd(&UT_CmdBuf.ResetResetsPerformedCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
@@ -1697,7 +1697,7 @@ void HS_SetMaxResetsCmd_Test(void)
     PayloadPtr->MaxResets = 5;
 
     /* Execute the function being tested */
-    HS_SetMaxResetsCmd(&UT_CmdBuf.Buf);
+    HS_SetMaxResetsCmd(&UT_CmdBuf.SetMaxResetsCmd);
 
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");

--- a/unit-test/hs_eds_dispatch_tests.c
+++ b/unit-test/hs_eds_dispatch_tests.c
@@ -17,40 +17,47 @@
  * limitations under the License.
  ************************************************************************/
 
-/**
- * @file
- *   CFS Health and Safety (HS) Application Message IDs
- */
-#ifndef HS_MSGIDS_H
-#define HS_MSGIDS_H
-
-#include "cfe_core_api_base_msgids.h"
-#include "hs_topicids.h"
-
-/**
- * \defgroup cfshscmdmid CFS Health and Safety Command Message IDs
- * \{
+/*
+ * Includes
  */
 
-/** \brief Msg ID for cmds to HS                */
-#define HS_CMD_MID CFE_PLATFORM_CMD_TOPICID_TO_MIDV(CFE_MISSION_HS_CMD_TOPICID)
+#include "hs_cmds.h"
+#include "hs_test_utils.h"
+#include "hs_dispatch.h"
+#include "hs_msgids.h"
 
-/** \brief Msg ID to request HS housekeeping    */
-#define HS_SEND_HK_MID CFE_PLATFORM_CMD_TOPICID_TO_MIDV(CFE_MISSION_HS_SEND_HK_TOPICID)
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
 
-/** \brief Msg ID to wake up HS                 */
-#define HS_WAKEUP_MID CFE_PLATFORM_CMD_TOPICID_TO_MIDV(CFE_MISSION_HS_WAKEUP_TOPICID)
+#include "cfe.h"
+#include "cfe_msg_dispatcher.h"
 
-/**\}*/
+/*
+**********************************************************************************
+**          TEST CASE FUNCTIONS
+**********************************************************************************
+*/
 
-/**
- * \defgroup cfshstlmmid CFS Health and Safety Telemetry Message IDs
- * \{
+void Test_HS_AppPipe(void)
+{
+    /*
+     * Test Case For:
+     * void HS_AppPipe
+     */
+    CFE_SB_Buffer_t UtBuf;
+
+    UT_SetDeferredRetcode(UT_KEY(CFE_MSG_EdsDispatch), 1, CFE_SUCCESS);
+
+    memset(&UtBuf, 0, sizeof(UtBuf));
+    UtAssert_VOIDCALL(HS_AppPipe(&UtBuf));
+}
+
+/*
+ * Register the test cases to execute with the unit test tool
  */
-
-/** \brief HS Housekeeping Telemetry            */
-#define HS_HK_TLM_MID CFE_PLATFORM_TLM_TOPICID_TO_MIDV(CFE_MISSION_HS_HK_TLM_TOPICID)
-
-/**\}*/
-
-#endif
+void UtTest_Setup(void)
+{
+    UtTest_Add(Test_HS_AppPipe, HS_Test_Setup, HS_Test_TearDown, "Test_HS_AppPipe");
+}

--- a/unit-test/stubs/hs_cmds_stubs.c
+++ b/unit-test/stubs/hs_cmds_stubs.c
@@ -53,11 +53,15 @@ void HS_AppMonStatusRefresh(void)
  * Generated stub function for HS_DisableAlivenessCmd()
  * ----------------------------------------------------
  */
-void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableAlivenessCmd(const HS_DisableAlivenessCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_DisableAlivenessCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_DisableAlivenessCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_DisableAlivenessCmd, const HS_DisableAlivenessCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_DisableAlivenessCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_DisableAlivenessCmd, CFE_Status_t);
 }
 
 /*
@@ -65,11 +69,15 @@ void HS_DisableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_DisableAppMonCmd()
  * ----------------------------------------------------
  */
-void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableAppMonCmd(const HS_DisableAppMonCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_DisableAppMonCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_DisableAppMonCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_DisableAppMonCmd, const HS_DisableAppMonCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_DisableAppMonCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_DisableAppMonCmd, CFE_Status_t);
 }
 
 /*
@@ -77,11 +85,15 @@ void HS_DisableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_DisableCpuHogCmd()
  * ----------------------------------------------------
  */
-void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableCpuHogCmd(const HS_DisableCpuHogCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_DisableCpuHogCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_DisableCpuHogCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_DisableCpuHogCmd, const HS_DisableCpuHogCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_DisableCpuHogCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_DisableCpuHogCmd, CFE_Status_t);
 }
 
 /*
@@ -89,11 +101,15 @@ void HS_DisableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_DisableEventMonCmd()
  * ----------------------------------------------------
  */
-void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_DisableEventMonCmd(const HS_DisableEventMonCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_DisableEventMonCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_DisableEventMonCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_DisableEventMonCmd, const HS_DisableEventMonCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_DisableEventMonCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_DisableEventMonCmd, CFE_Status_t);
 }
 
 /*
@@ -101,11 +117,15 @@ void HS_DisableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_EnableAlivenessCmd()
  * ----------------------------------------------------
  */
-void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableAlivenessCmd(const HS_EnableAlivenessCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_EnableAlivenessCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_EnableAlivenessCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_EnableAlivenessCmd, const HS_EnableAlivenessCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_EnableAlivenessCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_EnableAlivenessCmd, CFE_Status_t);
 }
 
 /*
@@ -113,11 +133,15 @@ void HS_EnableAlivenessCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_EnableAppMonCmd()
  * ----------------------------------------------------
  */
-void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableAppMonCmd(const HS_EnableAppMonCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_EnableAppMonCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_EnableAppMonCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_EnableAppMonCmd, const HS_EnableAppMonCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_EnableAppMonCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_EnableAppMonCmd, CFE_Status_t);
 }
 
 /*
@@ -125,11 +149,15 @@ void HS_EnableAppMonCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_EnableCpuHogCmd()
  * ----------------------------------------------------
  */
-void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableCpuHogCmd(const HS_EnableCpuHogCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_EnableCpuHogCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_EnableCpuHogCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_EnableCpuHogCmd, const HS_EnableCpuHogCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_EnableCpuHogCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_EnableCpuHogCmd, CFE_Status_t);
 }
 
 /*
@@ -137,11 +165,15 @@ void HS_EnableCpuHogCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_EnableEventMonCmd()
  * ----------------------------------------------------
  */
-void HS_EnableEventMonCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_EnableEventMonCmd(const HS_EnableEventMonCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_EnableEventMonCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_EnableEventMonCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_EnableEventMonCmd, const HS_EnableEventMonCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_EnableEventMonCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_EnableEventMonCmd, CFE_Status_t);
 }
 
 /*
@@ -160,11 +192,15 @@ void HS_MsgActsStatusRefresh(void)
  * Generated stub function for HS_NoopCmd()
  * ----------------------------------------------------
  */
-void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_NoopCmd(const HS_NoopCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_NoopCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_NoopCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_NoopCmd, const HS_NoopCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_NoopCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_NoopCmd, CFE_Status_t);
 }
 
 /*
@@ -172,11 +208,15 @@ void HS_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_ResetCmd()
  * ----------------------------------------------------
  */
-void HS_ResetCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_ResetCmd(const HS_ResetCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_ResetCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_ResetCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_ResetCmd, const HS_ResetCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_ResetCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_ResetCmd, CFE_Status_t);
 }
 
 /*
@@ -195,11 +235,15 @@ void HS_ResetCounters(void)
  * Generated stub function for HS_ResetResetsPerformedCmd()
  * ----------------------------------------------------
  */
-void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_ResetResetsPerformedCmd(const HS_ResetResetsPerformedCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_ResetResetsPerformedCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_ResetResetsPerformedCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_ResetResetsPerformedCmd, const HS_ResetResetsPerformedCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_ResetResetsPerformedCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_ResetResetsPerformedCmd, CFE_Status_t);
 }
 
 /*
@@ -207,11 +251,15 @@ void HS_ResetResetsPerformedCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_SendHkCmd()
  * ----------------------------------------------------
  */
-void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_SendHkCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_SendHkCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_SendHkCmd, const HS_SendHkCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_SendHkCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_SendHkCmd, CFE_Status_t);
 }
 
 /*
@@ -219,9 +267,13 @@ void HS_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HS_SetMaxResetsCmd()
  * ----------------------------------------------------
  */
-void HS_SetMaxResetsCmd(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t HS_SetMaxResetsCmd(const HS_SetMaxResetsCmd_t *BufPtr)
 {
-    UT_GenStub_AddParam(HS_SetMaxResetsCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_SetupReturnBuffer(HS_SetMaxResetsCmd, CFE_Status_t);
+
+    UT_GenStub_AddParam(HS_SetMaxResetsCmd, const HS_SetMaxResetsCmd_t *, BufPtr);
 
     UT_GenStub_Execute(HS_SetMaxResetsCmd, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HS_SetMaxResetsCmd, CFE_Status_t);
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Next step in adherence to established patterns for headers and dispatch code.

- Define MsgIDs for HS based on TopicIDs
- Define Command Handlers based on pattern (CFE_Status_t return, command structure type input)
- Define EDS dispatcher (only used in EDS builds)

Fixes #114

**Testing performed**
Build and run

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
Dispatch logic now has topicID-based definitions and fully supports EDS definitions via the eds_dispatch code.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
