### PR TITLE
Fix #113, use CFE_TBL_FILEDEF macro for table definitions

### DIFF
--- a/fsw/tables/hs_amt.c
+++ b/fsw/tables/hs_amt.c
@@ -31,9 +31,6 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_AppMon_Tbl", HS_APP_NAME ".AppMon_Tbl", "HS AppMon Table", "hs_amt.tbl",
-                                     (sizeof(HS_AMTEntry_t) * HS_MAX_MONITORED_APPS)};
-
 HS_AMTEntry_t HS_AppMon_Tbl[HS_MAX_MONITORED_APPS] = {
     /*          AppName                    NullTerm CycleCount     ActionType */
 
@@ -70,3 +67,5 @@ HS_AMTEntry_t HS_AppMon_Tbl[HS_MAX_MONITORED_APPS] = {
     /*  30 */ {"", 0, 10, HS_AMT_ACT_NOACT},
     /*  31 */ {"", 0, 10, HS_AMT_ACT_NOACT},
 };
+
+CFE_TBL_FILEDEF(HS_AppMon_Tbl, HS.AppMon_Tbl, HS AppMon Table, hs_amt.tbl)

--- a/fsw/tables/hs_mat.c
+++ b/fsw/tables/hs_mat.c
@@ -35,9 +35,6 @@
 #include "cfe_es_msg.h"
 #include "cfe_msgids.h"
 
-CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_Default_MsgActs_Tbl", HS_APP_NAME ".MsgActs_Tbl", "HS MsgActs Table",
-                                     "hs_mat.tbl", (sizeof(HS_MATEntry_t) * HS_MAX_MSG_ACT_TYPES)};
-
 /* Checksum for each desired command - Note that if checksum is enabled, real values (non-zero) must be input */
 #ifndef CFE_TBL_NOOP_CKSUM
 #define CFE_TBL_NOOP_CKSUM 0x00
@@ -66,7 +63,7 @@ typedef struct
 /* Helper macro to get size of structure elements */
 #define HS_MEMBER_SIZE(member) (sizeof(((HS_Message *)0)->member))
 
-HS_MatTableEntry_t HS_Default_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
+HS_MatTableEntry_t HS_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
     /*          EnableState               Cooldown   Message */
 
     /*   0 */
@@ -103,3 +100,5 @@ HS_MatTableEntry_t HS_Default_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
      .HsMsg.cmd1  = {CFE_MSG_CMD_HDR_INIT(CFE_TBL_CMD_MID, HS_MEMBER_SIZE(cmd1), CFE_TBL_NOOP_CC, CFE_TBL_NOOP_CKSUM)}}
 
 };
+
+CFE_TBL_FILEDEF(HS_MsgActs_Tbl, HS.MsgActs_Tbl, HS MsgActs Table, hs_mat.tbl)

--- a/fsw/tables/hs_xct.c
+++ b/fsw/tables/hs_xct.c
@@ -31,9 +31,6 @@
 #include "hs_tbldefs.h"
 #include "cfe_tbl_filedef.h"
 
-CFE_TBL_FileDef_t CFE_TBL_FileDef = {"HS_ExeCount_Tbl", HS_APP_NAME ".ExeCount_Tbl", "HS ExeCount Table", "hs_xct.tbl",
-                                     (sizeof(HS_XCTEntry_t) * HS_MAX_EXEC_CNT_SLOTS)};
-
 HS_XCTEntry_t HS_ExeCount_Tbl[HS_MAX_EXEC_CNT_SLOTS] = {
     /*          ResourceName               NullTerm ResourceType              */
 
@@ -70,3 +67,5 @@ HS_XCTEntry_t HS_ExeCount_Tbl[HS_MAX_EXEC_CNT_SLOTS] = {
     /*  30 */ {"", 0, HS_XCT_TYPE_NOTYPE},
     /*  31 */ {"", 0, HS_XCT_TYPE_NOTYPE},
 };
+
+CFE_TBL_FILEDEF(HS_ExeCount_Tbl, HS.ExeCount_Tbl, HS ExeCount Table, hs_xct.tbl)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The FILEDEF macro is intended to allow table source files to adapt to other tools and workflows more easily.  The macro should be used instead of instantiating the CFE_TBL_FileDef_t structure directly.

Fixes #113

**Testing performed**
Build HS (and tables)

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
The CFE_TBL_FILEDEF macro is the defined way to include table information in a source file.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
