### PR TITLE
Fix #121, fix incorrect macro usage

### DIFF
--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -326,7 +326,7 @@ void HS_MonitorEvent(const CFE_EVS_LongEventTlm_t *EventPtr)
                     default:
 
                         /* Calculate the requested message action index */
-                        MsgActsIndex = ActionType - HS_AMT_ACT_LAST_NONMSG - 1;
+                        MsgActsIndex = ActionType - HS_EMT_ACT_LAST_NONMSG - 1;
 
                         /*
                         ** Check to see if this is a valid Message Action Type


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Fixes #121

**Testing performed**
Steps taken to test the contribution:
1. Build and run unit test harness

**Expected behavior changes**
 - Behavior Change: correctly handle default behavior for event table monitoring when ```HS_EMT_ACT_LAST_NONMSG``` is not equal to ```HS_AMT_ACT_LAST_NONMSG```. 

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 22.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Lucien Morey - Personal - @LucienMorey
