### PR TITLE
Fix #126, Standardize command responses

### DIFF
--- a/config/default_hs_fcncodes.h
+++ b/config/default_hs_fcncodes.h
@@ -82,7 +82,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will be cleared
- *       - The #HS_RESET_INF_EID debug event message will be
+ *       - The #HS_RESET_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -114,7 +114,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentAppMonState will be set to Enabled
- *       - The #HS_ENABLE_APPMON_DBG_EID informational event message will be
+ *       - The #HS_ENABLE_APPMON_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -146,7 +146,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentAppMonState will be set to Disabled
- *       - The #HS_DISABLE_APPMON_DBG_EID informational event message will be
+ *       - The #HS_DISABLE_APPMON_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -178,7 +178,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentEventMonState will be set to Enabled
- *       - The #HS_ENABLE_EVENTMON_DBG_EID informational event message will be
+ *       - The #HS_ENABLE_EVENTMON_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -210,7 +210,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentEventMonState will be set to Disabled
- *       - The #HS_DISABLE_EVENTMON_DBG_EID informational event message will be
+ *       - The #HS_DISABLE_EVENTMON_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -242,7 +242,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentAlivenessState will be set to Enabled
- *       - The #HS_ENABLE_ALIVENESS_DBG_EID informational event message will be
+ *       - The #HS_ENABLE_ALIVENESS_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -274,7 +274,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentAlivenessState will be set to Disabled
- *       - The #HS_DISABLE_ALIVENESS_DBG_EID informational event message will be
+ *       - The #HS_DISABLE_ALIVENESS_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -306,7 +306,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.ResetsPerformed will be set to 0
- *       - The #HS_RESET_RESETS_DBG_EID informational event message will be
+ *       - The #HS_RESET_RESETS_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -338,7 +338,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.MaxResets will be set to the provided value
- *       - The #HS_SET_MAX_RESETS_DBG_EID informational event message will be
+ *       - The #HS_SET_MAX_RESETS_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -370,7 +370,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentCPUHogState will be set to Enabled
- *       - The #HS_ENABLE_CPUHOG_DBG_EID informational event message will be
+ *       - The #HS_ENABLE_CPUHOG_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -402,7 +402,7 @@
  *       the following telemetry:
  *       - #HS_HkTlm_Payload_t.CmdCount will increment
  *       - #HS_HkTlm_Payload_t.CurrentCPUHogState will be set to Disabled
- *       - The #HS_DISABLE_CPUHOG_DBG_EID informational event message will be
+ *       - The #HS_DISABLE_CPUHOG_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions

--- a/fsw/inc/hs_eventids.h
+++ b/fsw/inc/hs_eventids.h
@@ -325,98 +325,98 @@
 /**
  * \brief HS Enable Application Monitoring Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when an enable application monitoring
  *  command has been received.
  */
-#define HS_ENABLE_APPMON_DBG_EID 25
+#define HS_ENABLE_APPMON_INF_EID 25
 
 /**
  * \brief HS Disable Application Monitoring Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when a disable application monitoring
  *  command has been received.
  */
-#define HS_DISABLE_APPMON_DBG_EID 26
+#define HS_DISABLE_APPMON_INF_EID 26
 
 /**
  * \brief HS Enable Event Monitoring Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when an enable event monitoring
  *  command has been received.
  */
-#define HS_ENABLE_EVENTMON_DBG_EID 27
+#define HS_ENABLE_EVENTMON_INF_EID 27
 
 /**
  * \brief HS Disable Event Monitoring Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when a disable event monitoring
  *  command has been received.
  */
-#define HS_DISABLE_EVENTMON_DBG_EID 28
+#define HS_DISABLE_EVENTMON_INF_EID 28
 
 /**
  * \brief HS Enable Aliveness Indicator Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when an enable aliveness indicator
  *  command has been received.
  */
-#define HS_ENABLE_ALIVENESS_DBG_EID 29
+#define HS_ENABLE_ALIVENESS_INF_EID 29
 
 /**
  * \brief HS Disable Aliveness Indicator Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when a disable aliveness indicator
  *  command has been received.
  */
-#define HS_DISABLE_ALIVENESS_DBG_EID 30
+#define HS_DISABLE_ALIVENESS_INF_EID 30
 
 /**
  * \brief HS Reset Process Reset Counter Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when a reset processor resets count
  *  command has been received.
  */
-#define HS_RESET_RESETS_DBG_EID 31
+#define HS_RESET_RESETS_INF_EID 31
 
 /**
  * \brief HS Set Max Resets Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when a set max processor resets
  *  command has been received.
  */
-#define HS_SET_MAX_RESETS_DBG_EID 32
+#define HS_SET_MAX_RESETS_INF_EID 32
 
 /**
  * \brief HS AppMon Table Get Address Failed Event ID
@@ -777,26 +777,26 @@
 /**
  * \brief HS CPU Hogging Detection Enabled Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when an enable cpu hogging indicator
  *  command has been received.
  */
-#define HS_ENABLE_CPUHOG_DBG_EID 64
+#define HS_ENABLE_CPUHOG_INF_EID 64
 
 /**
  * \brief HS CPU Hogging Detection Disabled Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATIONAL
  *
  *  \par Cause:
  *
  *  This event message is issued when a disable cpu hogging indicator
  *  command has been received.
  */
-#define HS_DISABLE_CPUHOG_DBG_EID 65
+#define HS_DISABLE_CPUHOG_INF_EID 65
 
 /**
  * \brief HS Event Monitor Enable Subscribe To Long Events Failed Event ID

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -212,7 +212,8 @@ CFE_Status_t HS_ResetCmd(const HS_ResetCmd_t *BufPtr)
 {
     HS_ResetCounters();
 
-    CFE_EVS_SendEvent(HS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset counters command");
+    CFE_EVS_SendEvent(HS_RESET_INF_EID, CFE_EVS_EventType_INFORMATION,
+                      "Reset counters command");
     return CFE_SUCCESS;
 }
 
@@ -237,9 +238,19 @@ void HS_ResetCounters(void)
 CFE_Status_t HS_EnableAppMonCmd(const HS_EnableAppMonCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
-    HS_AppMonStatusRefresh();
-    HS_AppData.CurrentAppMonState = HS_STATE_ENABLED;
-    CFE_EVS_SendEvent(HS_ENABLE_APPMON_DBG_EID, CFE_EVS_EventType_DEBUG, "Application Monitoring Enabled");
+
+    if (HS_AppData.CurrentAppMonState == HS_STATE_ENABLED)
+    {
+        CFE_EVS_SendEvent(HS_ENABLE_APPMON_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Application Monitoring is *already* Enabled");
+    }
+    else
+    {
+        HS_AppMonStatusRefresh();
+        HS_AppData.CurrentAppMonState = HS_STATE_ENABLED;
+        CFE_EVS_SendEvent(HS_ENABLE_APPMON_INF_EID, CFE_EVS_EventType_INFORMATION, "Application Monitoring Enabled");
+    }
+
     return CFE_SUCCESS;
 }
 
@@ -251,8 +262,18 @@ CFE_Status_t HS_EnableAppMonCmd(const HS_EnableAppMonCmd_t *BufPtr)
 CFE_Status_t HS_DisableAppMonCmd(const HS_DisableAppMonCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
-    HS_AppData.CurrentAppMonState = HS_STATE_DISABLED;
-    CFE_EVS_SendEvent(HS_DISABLE_APPMON_DBG_EID, CFE_EVS_EventType_DEBUG, "Application Monitoring Disabled");
+
+    if (HS_AppData.CurrentAppMonState == HS_STATE_DISABLED)
+    {
+        CFE_EVS_SendEvent(HS_DISABLE_APPMON_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Application Monitoring is *already* Disabled");
+    }
+    else
+    {
+        HS_AppData.CurrentAppMonState = HS_STATE_DISABLED;
+        CFE_EVS_SendEvent(HS_DISABLE_APPMON_INF_EID, CFE_EVS_EventType_INFORMATION, "Application Monitoring Disabled");
+    }
+
     return CFE_SUCCESS;
 }
 
@@ -265,10 +286,12 @@ CFE_Status_t HS_EnableEventMonCmd(const HS_EnableEventMonCmd_t *BufPtr)
 {
     CFE_Status_t Status = CFE_SUCCESS;
 
-    /*
-    ** Subscribe to Event Messages if currently disabled
-    */
-    if (HS_AppData.CurrentEventMonState == HS_STATE_DISABLED)
+    if (HS_AppData.CurrentEventMonState == HS_STATE_ENABLED)
+    {
+        CFE_EVS_SendEvent(HS_ENABLE_EVENTMON_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Event Monitoring is *already* Enabled");
+    }
+    else
     {
         Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID), HS_AppData.EventPipe,
                                     CFE_SB_DEFAULT_QOS, HS_EVENT_PIPE_DEPTH);
@@ -277,7 +300,13 @@ CFE_Status_t HS_EnableEventMonCmd(const HS_EnableEventMonCmd_t *BufPtr)
             Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID), HS_AppData.EventPipe,
                                         CFE_SB_DEFAULT_QOS, HS_EVENT_PIPE_DEPTH);
 
-            if (Status != CFE_SUCCESS)
+            if (Status == CFE_SUCCESS)
+            {
+                HS_AppData.CurrentEventMonState = HS_STATE_ENABLED;
+                CFE_EVS_SendEvent(HS_ENABLE_EVENTMON_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                  "Event Monitoring Enabled");
+            }
+            else
             {
                 CFE_EVS_SendEvent(HS_EVENTMON_SHORT_SUB_EID, CFE_EVS_EventType_ERROR,
                                   "Event Monitor Enable: Error Subscribing to short-format Events,RC=0x%08X",
@@ -295,8 +324,6 @@ CFE_Status_t HS_EnableEventMonCmd(const HS_EnableEventMonCmd_t *BufPtr)
     if (Status == CFE_SUCCESS)
     {
         HS_AppData.CmdCount++;
-        HS_AppData.CurrentEventMonState = HS_STATE_ENABLED;
-        CFE_EVS_SendEvent(HS_ENABLE_EVENTMON_DBG_EID, CFE_EVS_EventType_DEBUG, "Event Monitoring Enabled");
     }
     else
     {
@@ -315,10 +342,12 @@ CFE_Status_t HS_DisableEventMonCmd(const HS_DisableEventMonCmd_t *BufPtr)
 {
     CFE_Status_t Status = CFE_SUCCESS;
 
-    /*
-    ** Unsubscribe from Event Messages if currently enabled
-    */
-    if (HS_AppData.CurrentEventMonState == HS_STATE_ENABLED)
+    if (HS_AppData.CurrentEventMonState == HS_STATE_DISABLED)
+    {
+        CFE_EVS_SendEvent(HS_DISABLE_EVENTMON_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Event Monitoring is *already* Disabled");
+    }
+    else
     {
         Status = CFE_SB_Unsubscribe(CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID), HS_AppData.EventPipe);
 
@@ -326,7 +355,13 @@ CFE_Status_t HS_DisableEventMonCmd(const HS_DisableEventMonCmd_t *BufPtr)
         {
             Status = CFE_SB_Unsubscribe(CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID), HS_AppData.EventPipe);
 
-            if (Status != CFE_SUCCESS)
+            if (Status == CFE_SUCCESS)
+            {
+                HS_AppData.CurrentEventMonState = HS_STATE_DISABLED;
+                CFE_EVS_SendEvent(HS_DISABLE_EVENTMON_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                  "Event Monitoring Disabled");
+            }
+            else
             {
                 CFE_EVS_SendEvent(HS_EVENTMON_SHORT_UNSUB_EID, CFE_EVS_EventType_ERROR,
                                   "Event Monitor Disable: Error Unsubscribing from short-format Events,RC=0x%08X",
@@ -344,8 +379,6 @@ CFE_Status_t HS_DisableEventMonCmd(const HS_DisableEventMonCmd_t *BufPtr)
     if (Status == CFE_SUCCESS)
     {
         HS_AppData.CmdCount++;
-        HS_AppData.CurrentEventMonState = HS_STATE_DISABLED;
-        CFE_EVS_SendEvent(HS_DISABLE_EVENTMON_DBG_EID, CFE_EVS_EventType_DEBUG, "Event Monitoring Disabled");
     }
     else
     {
@@ -363,8 +396,17 @@ CFE_Status_t HS_DisableEventMonCmd(const HS_DisableEventMonCmd_t *BufPtr)
 CFE_Status_t HS_EnableAlivenessCmd(const HS_EnableAlivenessCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
-    HS_AppData.CurrentAlivenessState = HS_STATE_ENABLED;
-    CFE_EVS_SendEvent(HS_ENABLE_ALIVENESS_DBG_EID, CFE_EVS_EventType_DEBUG, "Aliveness Indicator Enabled");
+
+    if (HS_AppData.CurrentAlivenessState == HS_STATE_ENABLED)
+    {
+        CFE_EVS_SendEvent(HS_ENABLE_ALIVENESS_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Aliveness Indicator is *already* Enabled");
+    }
+    else
+    {
+        HS_AppData.CurrentAlivenessState = HS_STATE_ENABLED;
+        CFE_EVS_SendEvent(HS_ENABLE_ALIVENESS_INF_EID, CFE_EVS_EventType_INFORMATION, "Aliveness Indicator Enabled");
+    }
 
     return CFE_SUCCESS;
 }
@@ -377,8 +419,17 @@ CFE_Status_t HS_EnableAlivenessCmd(const HS_EnableAlivenessCmd_t *BufPtr)
 CFE_Status_t HS_DisableAlivenessCmd(const HS_DisableAlivenessCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
-    HS_AppData.CurrentAlivenessState = HS_STATE_DISABLED;
-    CFE_EVS_SendEvent(HS_DISABLE_ALIVENESS_DBG_EID, CFE_EVS_EventType_DEBUG, "Aliveness Indicator Disabled");
+
+    if (HS_AppData.CurrentAlivenessState == HS_STATE_DISABLED)
+    {
+        CFE_EVS_SendEvent(HS_DISABLE_ALIVENESS_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Aliveness Indicator is *already* Disabled");
+    }
+    else
+    {
+        HS_AppData.CurrentAlivenessState = HS_STATE_DISABLED;
+        CFE_EVS_SendEvent(HS_DISABLE_ALIVENESS_INF_EID, CFE_EVS_EventType_INFORMATION, "Aliveness Indicator Disabled");
+    }
 
     return CFE_SUCCESS;
 }
@@ -391,8 +442,17 @@ CFE_Status_t HS_DisableAlivenessCmd(const HS_DisableAlivenessCmd_t *BufPtr)
 CFE_Status_t HS_EnableCpuHogCmd(const HS_EnableCpuHogCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
-    HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
-    CFE_EVS_SendEvent(HS_ENABLE_CPUHOG_DBG_EID, CFE_EVS_EventType_DEBUG, "CPU Hogging Indicator Enabled");
+
+    if (HS_AppData.CurrentCPUHogState == HS_STATE_ENABLED)
+    {
+        CFE_EVS_SendEvent(HS_ENABLE_CPUHOG_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "CPU Hogging Indicator is *already* Enabled");
+    }
+    else
+    {
+        HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
+        CFE_EVS_SendEvent(HS_ENABLE_CPUHOG_INF_EID, CFE_EVS_EventType_INFORMATION, "CPU Hogging Indicator Enabled");
+    }
 
     return CFE_SUCCESS;
 }
@@ -405,8 +465,17 @@ CFE_Status_t HS_EnableCpuHogCmd(const HS_EnableCpuHogCmd_t *BufPtr)
 CFE_Status_t HS_DisableCpuHogCmd(const HS_DisableCpuHogCmd_t *BufPtr)
 {
     HS_AppData.CmdCount++;
-    HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
-    CFE_EVS_SendEvent(HS_DISABLE_CPUHOG_DBG_EID, CFE_EVS_EventType_DEBUG, "CPU Hogging Indicator Disabled");
+
+    if (HS_AppData.CurrentCPUHogState == HS_STATE_DISABLED)
+    {
+        CFE_EVS_SendEvent(HS_DISABLE_CPUHOG_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "CPU Hogging Indicator is *already* Disabled");
+    }
+    else
+    {
+        HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
+        CFE_EVS_SendEvent(HS_DISABLE_CPUHOG_INF_EID, CFE_EVS_EventType_INFORMATION, "CPU Hogging Indicator Disabled");
+    }
 
     return CFE_SUCCESS;
 }
@@ -420,7 +489,7 @@ CFE_Status_t HS_ResetResetsPerformedCmd(const HS_ResetResetsPerformedCmd_t *BufP
 {
     HS_AppData.CmdCount++;
     HS_SetCDSData(0, HS_AppData.CDSData.MaxResets);
-    CFE_EVS_SendEvent(HS_RESET_RESETS_DBG_EID, CFE_EVS_EventType_DEBUG,
+    CFE_EVS_SendEvent(HS_RESET_RESETS_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Processor Resets Performed by HS Counter has been Reset");
 
     return CFE_SUCCESS;
@@ -440,7 +509,7 @@ CFE_Status_t HS_SetMaxResetsCmd(const HS_SetMaxResetsCmd_t *BufPtr)
 
     HS_SetCDSData(HS_AppData.CDSData.ResetsPerformed, CmdPtr->MaxResets);
 
-    CFE_EVS_SendEvent(HS_SET_MAX_RESETS_DBG_EID, CFE_EVS_EventType_DEBUG,
+    CFE_EVS_SendEvent(HS_SET_MAX_RESETS_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Max Resets Performable by HS has been set to %d", HS_AppData.CDSData.MaxResets);
 
     return CFE_SUCCESS;

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -1035,7 +1035,8 @@ void HS_ResetCmd_Test(void)
     UtAssert_True(HS_AppData.CmdCount == 0, "HS_AppData.CmdCount == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_RESET_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType,
+                      CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1084,6 +1085,9 @@ void HS_EnableAppMonCmd_Test(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
+    /* Set to Disabled so the function can freshly set it to Enabled (without it already being set that way) */
+    HS_AppData.CurrentAppMonState = HS_STATE_DISABLED;
+
     /* Execute the function being tested */
     HS_EnableAppMonCmd(&UT_CmdBuf.EnableAppMonCmd);
 
@@ -1093,8 +1097,54 @@ void HS_EnableAppMonCmd_Test(void)
     UtAssert_True(HS_AppData.CurrentAppMonState == HS_STATE_ENABLED,
                   "HS_AppData.CurrentAppMonState == HS_STATE_ENABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_APPMON_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_APPMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+
+    strCmpResult =
+        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+
+    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+                  call_count_CFE_EVS_SendEvent);
+}
+
+void HS_EnableAppMonCmd_Test_AlreadyEnabled(void)
+{
+    CFE_SB_MsgId_t    TestMsgId;
+    CFE_MSG_FcnCode_t FcnCode;
+    size_t            MsgSize;
+    HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
+    int32             strCmpResult;
+    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Application Monitoring is *already* Enabled");
+
+    memset(AMTable, 0, sizeof(AMTable));
+
+    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
+    FcnCode   = HS_ENABLE_APP_MON_CC;
+    MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    HS_AppData.AMTablePtr = AMTable;
+
+    /* Set to Enabled to test response when already in the commanded state. */
+    HS_AppData.CurrentAppMonState = HS_STATE_ENABLED;
+
+    /* Execute the function being tested */
+    HS_EnableAppMonCmd(&UT_CmdBuf.EnableAppMonCmd);
+
+    /* Verify results */
+    UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
+
+    UtAssert_True(HS_AppData.CurrentAppMonState == HS_STATE_ENABLED,
+                  "HS_AppData.CurrentAppMonState == HS_STATE_ENABLED");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_APPMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1122,6 +1172,9 @@ void HS_DisableAppMonCmd_Test(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
+    /* Set to Enabled so the function can freshly set it to Disabled (without it already being set that way) */
+    HS_AppData.CurrentAppMonState = HS_STATE_ENABLED;
+
     /* Execute the function being tested */
     HS_DisableAppMonCmd(&UT_CmdBuf.DisableAppMonCmd);
 
@@ -1131,8 +1184,50 @@ void HS_DisableAppMonCmd_Test(void)
     UtAssert_True(HS_AppData.CurrentAppMonState == HS_STATE_DISABLED,
                   "HS_AppData.CurrentAppMonState == HS_STATE_DISABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_APPMON_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_APPMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+
+    strCmpResult =
+        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+
+    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+                  call_count_CFE_EVS_SendEvent);
+}
+
+void HS_DisableAppMonCmd_Test_AlreadyDisabled(void)
+{
+    CFE_SB_MsgId_t    TestMsgId;
+    CFE_MSG_FcnCode_t FcnCode;
+    size_t            MsgSize;
+    int32             strCmpResult;
+    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
+             "Application Monitoring is *already* Disabled");
+
+    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
+    FcnCode   = HS_DISABLE_APP_MON_CC;
+    MsgSize   = sizeof(UT_CmdBuf.DisableAppMonCmd);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    /* Set to Disabled to test response when already in the commanded state. */
+    HS_AppData.CurrentAppMonState = HS_STATE_DISABLED;
+
+    /* Execute the function being tested */
+    HS_DisableAppMonCmd(&UT_CmdBuf.DisableAppMonCmd);
+
+    /* Verify results */
+    UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
+
+    UtAssert_True(HS_AppData.CurrentAppMonState == HS_STATE_DISABLED,
+                  "HS_AppData.CurrentAppMonState == HS_STATE_DISABLED");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_APPMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1171,8 +1266,8 @@ void HS_EnableEventMonCmd_Test_Disabled(void)
     UtAssert_True(HS_AppData.CurrentEventMonState == HS_STATE_ENABLED,
                   "HS_AppData.CurrentEventMonState == HS_STATE_ENABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_EVENTMON_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_EVENTMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1191,7 +1286,7 @@ void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
     size_t            MsgSize;
     int32             strCmpResult;
     char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring Enabled");
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring is *already* Enabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_ENABLE_EVENT_MON_CC;
@@ -1211,8 +1306,8 @@ void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
     UtAssert_True(HS_AppData.CurrentEventMonState == HS_STATE_ENABLED,
                   "HS_AppData.CurrentEventMonState == HS_STATE_ENABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_EVENTMON_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_EVENTMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1337,8 +1432,8 @@ void HS_DisableEventMonCmd_Test_Enabled(void)
     UtAssert_True(HS_AppData.CurrentEventMonState == HS_STATE_DISABLED,
                   "HS_AppData.CurrentEventMonState == HS_STATE_DISABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_EVENTMON_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_EVENTMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1357,7 +1452,7 @@ void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
     size_t            MsgSize;
     int32             strCmpResult;
     char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring Disabled");
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Event Monitoring is *already* Disabled");
 
     TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
     FcnCode   = HS_DISABLE_EVENT_MON_CC;
@@ -1377,8 +1472,8 @@ void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
     UtAssert_True(HS_AppData.CurrentEventMonState == HS_STATE_DISABLED,
                   "HS_AppData.CurrentEventMonState == HS_STATE_DISABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_EVENTMON_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_EVENTMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1503,8 +1598,48 @@ void HS_EnableAlivenessCmd_Test(void)
     UtAssert_True(HS_AppData.CurrentAlivenessState == HS_STATE_ENABLED,
                   "HS_AppData.CurrentAlivenessState == HS_STATE_ENABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_ALIVENESS_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_ALIVENESS_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+
+    strCmpResult =
+        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+
+    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+                  call_count_CFE_EVS_SendEvent);
+}
+
+void HS_EnableAlivenessCmd_Test_AlreadyEnabled(void)
+{
+    CFE_SB_MsgId_t    TestMsgId;
+    CFE_MSG_FcnCode_t FcnCode;
+    size_t            MsgSize;
+    int32             strCmpResult;
+    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Aliveness Indicator is *already* Enabled");
+
+    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
+    FcnCode   = HS_ENABLE_ALIVENESS_CC;
+    MsgSize   = sizeof(UT_CmdBuf.EnableAlivenessCmd);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    HS_AppData.CurrentAlivenessState = HS_STATE_ENABLED;
+
+    /* Execute the function being tested */
+    HS_EnableAlivenessCmd(&UT_CmdBuf.EnableAlivenessCmd);
+
+    /* Verify results */
+    UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
+
+    UtAssert_True(HS_AppData.CurrentAlivenessState == HS_STATE_ENABLED,
+                  "HS_AppData.CurrentAlivenessState == HS_STATE_ENABLED");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_ALIVENESS_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1543,8 +1678,48 @@ void HS_DisableAlivenessCmd_Test(void)
     UtAssert_True(HS_AppData.CurrentAlivenessState == HS_STATE_DISABLED,
                   "HS_AppData.CurrentAlivenessState == HS_STATE_DISABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_ALIVENESS_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_ALIVENESS_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+
+    strCmpResult =
+        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+
+    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+                  call_count_CFE_EVS_SendEvent);
+}
+
+void HS_DisableAlivenessCmd_Test_AlreadyDisabled(void)
+{
+    CFE_SB_MsgId_t    TestMsgId;
+    CFE_MSG_FcnCode_t FcnCode;
+    size_t            MsgSize;
+    int32             strCmpResult;
+    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Aliveness Indicator is *already* Disabled");
+
+    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
+    FcnCode   = HS_DISABLE_ALIVENESS_CC;
+    MsgSize   = sizeof(UT_CmdBuf.DisableAlivenessCmd);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    HS_AppData.CurrentAlivenessState = HS_STATE_DISABLED;
+
+    /* Execute the function being tested */
+    HS_DisableAlivenessCmd(&UT_CmdBuf.DisableAlivenessCmd);
+
+    /* Verify results */
+    UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
+
+    UtAssert_True(HS_AppData.CurrentAlivenessState == HS_STATE_DISABLED,
+                  "HS_AppData.CurrentAlivenessState == HS_STATE_DISABLED");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_ALIVENESS_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1583,8 +1758,48 @@ void HS_EnableCpuHogCmd_Test(void)
     UtAssert_True(HS_AppData.CurrentCPUHogState == HS_STATE_ENABLED,
                   "HS_AppData.CurrentCPUHogState == HS_STATE_ENABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_CPUHOG_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_CPUHOG_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+
+    strCmpResult =
+        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+
+    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+                  call_count_CFE_EVS_SendEvent);
+}
+
+void HS_EnableCpuHogCmd_Test_AlreadyEnabled(void)
+{
+    CFE_SB_MsgId_t    TestMsgId;
+    CFE_MSG_FcnCode_t FcnCode;
+    size_t            MsgSize;
+    int32             strCmpResult;
+    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CPU Hogging Indicator is *already* Enabled");
+
+    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
+    FcnCode   = HS_ENABLE_CPU_HOG_CC;
+    MsgSize   = sizeof(UT_CmdBuf.EnableCpuHogCmd);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    HS_AppData.CurrentCPUHogState = HS_STATE_ENABLED;
+
+    /* Execute the function being tested */
+    HS_EnableCpuHogCmd(&UT_CmdBuf.EnableCpuHogCmd);
+
+    /* Verify results */
+    UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
+
+    UtAssert_True(HS_AppData.CurrentCPUHogState == HS_STATE_ENABLED,
+                  "HS_AppData.CurrentCPUHogState == HS_STATE_ENABLED");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_CPUHOG_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1623,8 +1838,48 @@ void HS_DisableCpuHogCmd_Test(void)
     UtAssert_True(HS_AppData.CurrentCPUHogState == HS_STATE_DISABLED,
                   "HS_AppData.CurrentCPUHogState == HS_STATE_DISABLED");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_CPUHOG_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_CPUHOG_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+
+    strCmpResult =
+        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+
+    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+
+    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
+                  call_count_CFE_EVS_SendEvent);
+}
+
+void HS_DisableCpuHogCmd_Test_AlreadyDisabled(void)
+{
+    CFE_SB_MsgId_t    TestMsgId;
+    CFE_MSG_FcnCode_t FcnCode;
+    size_t            MsgSize;
+    int32             strCmpResult;
+    char              ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CPU Hogging Indicator is *already* Disabled");
+
+    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
+    FcnCode   = HS_DISABLE_CPU_HOG_CC;
+    MsgSize   = sizeof(UT_CmdBuf.DisableCpuHogCmd);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    HS_AppData.CurrentCPUHogState = HS_STATE_DISABLED;
+
+    /* Execute the function being tested */
+    HS_DisableCpuHogCmd(&UT_CmdBuf.DisableCpuHogCmd);
+
+    /* Verify results */
+    UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
+
+    UtAssert_True(HS_AppData.CurrentCPUHogState == HS_STATE_DISABLED,
+                  "HS_AppData.CurrentCPUHogState == HS_STATE_DISABLED");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_DISABLE_CPUHOG_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1659,8 +1914,8 @@ void HS_ResetResetsPerformedCmd_Test(void)
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_RESET_RESETS_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_RESET_RESETS_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -1702,8 +1957,8 @@ void HS_SetMaxResetsCmd_Test(void)
     /* Verify results */
     UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_SET_MAX_RESETS_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_SET_MAX_RESETS_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult =
         strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -2313,7 +2568,13 @@ void UtTest_Setup(void)
 
     UtTest_Add(HS_EnableAppMonCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableAppMonCmd_Test");
 
+    UtTest_Add(HS_EnableAppMonCmd_Test_AlreadyEnabled, HS_Test_Setup, HS_Test_TearDown,
+               "HS_EnableAppMonCmd_Test_AlreadyEnabled");
+
     UtTest_Add(HS_DisableAppMonCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableAppMonCmd_Test");
+
+    UtTest_Add(HS_DisableAppMonCmd_Test_AlreadyDisabled, HS_Test_Setup, HS_Test_TearDown,
+               "HS_DisableAppMonCmd_Test_AlreadyDisabled");
 
     UtTest_Add(HS_EnableEventMonCmd_Test_Disabled, HS_Test_Setup, HS_Test_TearDown,
                "HS_EnableEventMonCmd_Test_Disabled");
@@ -2336,11 +2597,23 @@ void UtTest_Setup(void)
 
     UtTest_Add(HS_EnableAlivenessCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableAlivenessCmd_Test");
 
+    UtTest_Add(HS_EnableAlivenessCmd_Test_AlreadyEnabled, HS_Test_Setup, HS_Test_TearDown,
+               "HS_EnableAlivenessCmd_Test_AlreadyEnabled");
+
     UtTest_Add(HS_DisableAlivenessCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableAlivenessCmd_Test");
+
+    UtTest_Add(HS_DisableAlivenessCmd_Test_AlreadyDisabled, HS_Test_Setup, HS_Test_TearDown,
+               "HS_DisableAlivenessCmd_Test_AlreadyDisabled");
 
     UtTest_Add(HS_EnableCpuHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableCpuHogCmd_Test");
 
+    UtTest_Add(HS_EnableCpuHogCmd_Test_AlreadyEnabled, HS_Test_Setup, HS_Test_TearDown,
+               "HS_EnableCpuHogCmd_Test_AlreadyEnabled");
+
     UtTest_Add(HS_DisableCpuHogCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_DisableCpuHogCmd_Test");
+
+    UtTest_Add(HS_DisableCpuHogCmd_Test_AlreadyDisabled, HS_Test_Setup, HS_Test_TearDown,
+               "HS_DisableCpuHogCmd_Test_AlreadyDisabled");
 
     UtTest_Add(HS_ResetResetsPerformedCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_ResetResetsPerformedCmd_Test");
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #126 
  - Adds checks if already in the commanded state (where it makes sense - for example, not for resetting the command counters or for the NOOP)
  - Issues an event string to that effect informing the user that we are already in the commanded state (but still reuses the same EID)
  - Adds 6 new tests for the new logic
  - couple of unrelated typos etc. fixed as well

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
New tests added for added functionality.

**Expected behavior changes**
HS command responses will now align fully with expectations, and will inform the user if the software is already in the commanded state (and not set it again unnessesarily).

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt