### PR TITLE
ci: declare workflow-level `contents: read` on 6 workflows

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-documentation:
     name: Build and deploy cFS documents

--- a/.github/workflows/build-run-app.yml
+++ b/.github/workflows/build-run-app.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     # 9:35 PM UTC every Sunday
     - cron:  '35 21 * * 0'
+
+permissions:
+  contents: read
+
 jobs:
   build-run:
     name: Build and run with startup msg verification

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -13,6 +13,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: Run format check

--- a/.github/workflows/mcdc.yml
+++ b/.github/workflows/mcdc.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   mcdc:
     name: Run MCDC Analysis

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
     name: Static Analysis

--- a/.github/workflows/unit-test-coverage.yml
+++ b/.github/workflows/unit-test-coverage.yml
@@ -15,6 +15,9 @@ on:
     # 9:25 PM UTC every Sunday
     - cron:  '25 21 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   unit-test-coverage:
     name: Run unit test and coverage


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 6 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `add-to-project.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.