### PR TITLE
Guard AMTablePtr null in HS_AppMonStatusRefresh

### DIFF
--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -764,6 +764,12 @@ void HS_AppMonStatusRefresh(void)
     uint32 TableIndex  = 0;
     uint32 EnableIndex = 0;
 
+    /* Avoid accessing AMT if table pointer is invalid */
+    if (HS_AppData.AMTablePtr == NULL)
+    {
+        return;
+    }
+
     /*
     ** Clear all AppMon Enable bits
     */

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -2619,6 +2619,20 @@ void HS_AppMonStatusRefresh_Test_CycleCountZero(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
+void HS_AppMonStatusRefresh_Test_AppMonTblPtrNull(void)
+{
+    HS_AppData.AMTablePtr = NULL;
+
+    HS_AppData.AppMonEnables[0] = 1;
+
+    /* Execute the function being tested */
+    HS_AppMonStatusRefresh();
+
+    /* Verify results */
+    /* UUT returns early without touching the enable bits when the table pointer is invalid */
+    UtAssert_True(HS_AppData.AppMonEnables[0] == 1, "HS_AppData.AppMonEnables[0] == 1");
+}
+
 void HS_AppMonStatusRefresh_Test_ActionTypeNOACT(void)
 {
     HS_AMTEntry_t AMTable[HS_MAX_MONITORED_APPS];
@@ -2908,6 +2922,10 @@ void UtTest_Setup(void)
                HS_Test_Setup,
                HS_Test_TearDown,
                "HS_AppMonStatusRefresh_Test_CycleCountZero");
+    UtTest_Add(HS_AppMonStatusRefresh_Test_AppMonTblPtrNull,
+               HS_Test_Setup,
+               HS_Test_TearDown,
+               "HS_AppMonStatusRefresh_Test_AppMonTblPtrNull");
     UtTest_Add(HS_AppMonStatusRefresh_Test_ActionTypeNOACT,
                HS_Test_Setup,
                HS_Test_TearDown,


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**


`HS_AppMonStatusRefresh()` indexes `HS_AppData.AMTablePtr[]` without checking for a null pointer. If the AppMon table is registered but not yet loaded when `HS_EnableAppMonCmd` runs, `AMTablePtr` is still NULL and the enable command dereferences it and crashes. Because the same refresh runs on table update as well as on enable, this adds the same `AMTablePtr == NULL` early return already used in `HS_MonitorApplications` so the refresh is skipped when the table is not loaded.

**Testing performed**
Added `HS_AppMonStatusRefresh_Test_AppMonTblPtrNull` to the coverage suite, which sets `AMTablePtr` to NULL and verifies the refresh returns without touching the enable bits. I was not able to run the full cFS coverage build locally, but the change and test mirror the existing null-table handling and its test in the app monitor path.

**Expected behavior changes**
 - Behavior Change: enabling the application monitor before its table is loaded no longer dereferences a null pointer; the refresh is skipped until the table is available.

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu
 - Versions: cFE/OSAL/PSP as bundled with the current dev branch

**Additional context**
The added guard matches the existing check at the top of `HS_MonitorApplications` in `fsw/src/hs_monitors.c`.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Sai Asish Y, Personal