### PR TITLE
Fix #152, Remove Dead Functions

### DIFF
--- a/unit-test/hs_app_tests.c
+++ b/unit-test/hs_app_tests.c
@@ -47,7 +47,6 @@ typedef struct
 /* hs_app_tests globals */
 uint8 call_count_CFE_EVS_SendEvent;
 
-uint16 HS_APP_TEST_CFE_SB_RcvMsgHookCount;
 uint32 UT_WaitForStartupSyncTimeout;
 
 void UT_UpdatedDefaultHandler_CFE_SB_ReceiveBuffer(void                   *UserObj,
@@ -55,33 +54,6 @@ void UT_UpdatedDefaultHandler_CFE_SB_ReceiveBuffer(void                   *UserO
                                                    const UT_StubContext_t *Context)
 {
     CFE_SB_Buffer_t **BufPtr = UT_Hook_GetArgValueByName(Context, "BufPtr", CFE_SB_Buffer_t **);
-    UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ReceiveBuffer), BufPtr, sizeof(*BufPtr));
-}
-
-int32 HS_APP_TEST_CFE_SB_RcvMsgHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
-{
-    HS_APP_TEST_CFE_SB_RcvMsgHookCount++;
-
-    if (HS_APP_TEST_CFE_SB_RcvMsgHookCount % 2 == 1)
-        return CFE_SUCCESS;
-    else
-        return CFE_SB_NO_MESSAGE;
-}
-
-void HS_APP_TEST_CFE_RcvBufferHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
-{
-    CFE_SB_Buffer_t **BufPtr = UT_Hook_GetArgValueByName(Context, "BufPtr", CFE_SB_Buffer_t **);
-
-    CFE_Status_t status;
-    HS_APP_TEST_CFE_SB_RcvMsgHookCount++;
-
-    if (HS_APP_TEST_CFE_SB_RcvMsgHookCount % 2 == 1)
-        status = CFE_SUCCESS;
-    else
-        status = CFE_SB_NO_MESSAGE;
-
-    UT_Stub_GetInt32StatusCode(Context, &status);
-
     UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ReceiveBuffer), BufPtr, sizeof(*BufPtr));
 }
 
@@ -1955,7 +1927,6 @@ void HS_ProcessCommands_Test(void)
     }
 
     /* Causes CFE_SB_RcvMsg to alternate returning CFE_SUCCESS and CFE_SB_NO_MESSAGE, to reach all code branches. */
-    HS_APP_TEST_CFE_SB_RcvMsgHookCount = 0;
     CFE_SB_Buffer_t *dummy_BufPtr[4];
     CFE_SB_Buffer_t  dummy_Buf[4];
     dummy_BufPtr[0] = &dummy_Buf[0];
@@ -1967,10 +1938,6 @@ void HS_ProcessCommands_Test(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 2, CFE_SB_NO_MESSAGE);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 2, CFE_SB_NO_MESSAGE);
-    /* UT_SetHookFunction(UT_KEY(CFE_SB_ReceiveBuffer), HS_APP_TEST_CFE_SB_RcvMsgHook, NULL); */
-
-    /* Causes check for non-null buffer pointer to succeed */
-    /* UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), &Packet, sizeof(Packet), false); */
 
     /* Execute the function being tested */
     Result = HS_ProcessCommands();

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -2436,46 +2436,6 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoS
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
 }
 
-void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoSubscribeError2(void)
-{
-    HS_AppData.AppMonLoaded         = HS_State_DISABLED;
-    HS_AppData.EventMonLoaded       = HS_State_DISABLED;
-    HS_AppData.CurrentAppMonState   = HS_State_ENABLED;
-    HS_AppData.CurrentEventMonState = HS_State_DISABLED;
-    HS_AppData.MsgActsState         = HS_State_ENABLED;
-    HS_AppData.ExeCountState        = HS_State_ENABLED;
-
-    /* Causes to enter all (Status < CFE_SUCCESS) blocks */
-    UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), -1);
-
-    /* Causes event message HS_BADEMT_UNSUB_EID to not be generated */
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Unsubscribe), 2, -1);
-
-    /* Execute the function being tested */
-    HS_AcquirePointers();
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CurrentAppMonState == HS_State_DISABLED,
-                  "HS_AppData.CurrentAppMonState == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.AppMonLoaded == HS_State_DISABLED, "HS_AppData.AppMonLoaded == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.CurrentEventMonState == HS_State_DISABLED,
-                  "HS_AppData.CurrentEventMonState == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.EventMonLoaded == HS_State_DISABLED, "HS_AppData.EventMonLoaded == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.MsgActsState == HS_State_DISABLED, "HS_AppData.MsgActsState == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.ExeCountState == HS_State_DISABLED, "HS_AppData.ExeCountState == HS_State_DISABLED");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_GETADDR_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_MSGACTS_GETADDR_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, HS_EXECOUNT_GETADDR_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventType, CFE_EVS_EventType_ERROR);
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
-}
-
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppMonStateDisabled(void)
 {
     HS_AppData.AppMonLoaded         = HS_State_DISABLED;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #152 

**Testing performed**
Ran the native_std commands which includes prep, install, runtest, and lcov. Compared these lcov results against the unchanged cFS bundle and found no changes. Ran the old build commands with unit tests enabled to ensure that the internal static code analysis tool no longer flags these functions. Also ran the bundle with -Wunused flags which only flagged unrelated macros.

**Expected behavior changes**
Removes three dead functions which are HS_APP_TEST_CFE_SB_RcvMsgHook, HS_APP_TEST_CFE_RcvBufferHandler, and HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoSubscribeError2. 

**System(s) tested on**
RedHat, cFS dev

**Additional context**
Lcov results using native_std:
```
Overall coverage rate:
  lines......: 99.2% (30304 of 30537 lines)
  functions..: 99.2% (2428 of 2447 functions)
  branches...: no data found
```
Lcov results using the old build commands:
```
Overall coverage rate:
  lines......: 99.2% (30167 of 30396 lines)
  functions..: 99.2% (2417 of 2436 functions)
  branches...: 98.7% (12931 of 13095 branches)
```

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
