### PR TITLE
Fix nasa#155 - Replaced zero with NULL in #define HS_MEMBER_SIZE.

### DIFF
--- a/fsw/tables/hs_mat.c
+++ b/fsw/tables/hs_mat.c
@@ -60,7 +60,7 @@ typedef struct
 } HS_MatTableEntry_t;
 
 /* Helper macro to get size of structure elements */
-#define HS_MEMBER_SIZE(member) (sizeof(((HS_Message *)0)->member))
+#define HS_MEMBER_SIZE(member) (sizeof(((HS_Message *)NULL)->member))
 
 HS_MatTableEntry_t HS_MsgActs_Tbl[HS_MAX_MSG_ACT_TYPES] = {
     /*          EnableState               Cooldown   Message */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #155 - Replaced zero with NULL in #define HS_MEMBER_SIZE.

**Testing performed**
Ran the Axle static code analysis tool and it no longer reported any findings in hs_mat.c when I ran the `literal-zero-used-as-null-pointer` query.  

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Linux

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang / NASA GSFC

**For members of the cFS Team**
Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
- [Workflows Change](?expand=1&template=workflows_change.md)
