### PR TITLE
Fix: do not decrement check-in countdown for nonexistent app names

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
@@ -1,0 +1,50 @@
+---
+name: Comment / Documentation Change
+about: Changes limited to comments, README, docstrings, or other documentation
+labels: documentation
+---
+
+## Description of Change
+
+<!-- Briefly describe what documentation/comments were changed and why. -->
+
+## Linked Issue
+
+<!-- Required. Reference the GitHub issue this PR addresses, e.g., Closes #123 -->
+Closes #
+
+## Areas of Expertise Touched
+
+<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above/linked to this PR
+- [ ] Documentation generation workflow ran successfully on this branch
+- [ ] Changes are limited to documentation/comments (no code behavior changes)
+
+---
+
+## Reviewer Checklist
+
+- [ ] Documentation is clear, accurate, and complete
+- [ ] Spelling and grammar reviewed
+- [ ] Any links in the documentation have been verified to work
+- [ ] Documentation generation workflow output looks correct
+- [ ] Appropriate Expert areas have been reviewed

--- a/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
@@ -1,0 +1,88 @@
+---
+name: FSW Code Change
+about: Flight Software code changes
+labels: fsw
+---
+
+## Description of Change
+
+<!-- Describe what was changed, why, and how. Include any design notes that will help reviewers. -->
+
+## Linked Issue
+
+Closes #
+
+## Requirements Impact
+
+<!-- List any requirements impacted by this change. Indicate whether each was updated, or confirm the change continues to satisfy existing requirements. -->
+- Requirement ID(s):
+- [ ] Requirements updated as necessary
+- [ ] Existing requirements are still satisfied by this change
+
+## Testing Evidence
+
+<!-- Paste relevant test output, link to CI runs, or attach screenshots. -->
+
+### Unit Tests (UT Assert)
+<!-- Link to CI run or paste summary -->
+
+### COSMOS Test Suite
+<!-- Link to CI run, paste summary, or note "N/A — no relevant changes" -->
+
+## Areas of Expertise Touched
+
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above
+- [ ] Code has been formatted with `.clang-format`
+- [ ] Static analysis workflows ran and passed
+- [ ] Unit tests (UT Assert) updated/added to cover code changes
+- [ ] Unit test workflows ran and passed
+- [ ] COSMOS test suite was run; tests updated/added if relevant changes were made
+- [ ] Requirements have been reviewed; updated or confirmed still satisfied (see above)
+- [ ] Testing evidence is included above
+- [ ] Self-review of the diff completed
+
+---
+
+## Reviewer Checklist
+
+- [ ] Code logic is correct and matches the stated intent
+- [ ] Code is readable, maintainable, and follows project conventions
+- [ ] `.clang-format` has been applied
+- [ ] Static analysis results reviewed and acceptable
+- [ ] Unit tests are meaningful and adequately cover the changes
+- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
+- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
+- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
+- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
+- [ ] Requirements impact reviewed and appropriate
+- [ ] Error handling is appropriate
+- [ ] Appropriate Expert areas have been reviewed
+
+### Reviewer Testing Notes
+
+<!--
+Describe how you independently verified this change. For example:
+  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
+  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
+  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
+  - "Performed ad-hoc test by [describe scenario]; observed [result]."
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
@@ -1,0 +1,50 @@
+---
+name: Workflows Change
+about: Changes to files under .github/workflows/
+labels: ci/workflows
+---
+
+## Description of Change
+
+<!-- Describe what workflow(s) were changed and why. -->
+
+## Linked Issue
+
+Closes #
+
+## Areas of Expertise Touched
+
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above
+- [ ] Workflow changes were tested on a branch/fork before submitting this PR
+- [ ] All workflows ran successfully on this branch
+
+---
+
+## Reviewer Checklist
+
+- [ ] Workflow logic is correct and achieves the stated goal
+- [ ] Third-party actions are from trusted sources and pinned to a specific SHA/tag
+- [ ] Secrets are handled appropriately (no secrets exposed in logs, least-privilege usage)
+- [ ] Workflow permissions follow the principle of least privilege
+- [ ] Changes do not break or bypass existing branch protection rules
+- [ ] All workflow runs on this PR completed successfully
+- [ ] Appropriate Expert areas have been reviewed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,3 +32,9 @@ If included, identify any third party code and provide text file of license
 **Contributor Info - All information REQUIRED for consideration of pull request**
 Full name and company/organization/center of all contributors ("Personal" if individual work)
  - Note CLA's apply to software contributions.
+
+**For members of the cFS Team**
+Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
+- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
+- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
+- [Workflows Change](?expand=1&template=workflows_change.md)

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,5 @@
 name: Static Analysis
 
-# Run on all push and pull requests
 on:
   push:
     branches:
@@ -16,4 +15,6 @@ on:
 jobs:
   static-analysis:
     name: Static Analysis
-    uses: nasa/cFS/.github/workflows/app-static-analysis-reusable.yml@dev
+    uses: nasa/cFS/.github/workflows/static-analysis-reusable.yml@dev
+    with:
+      source-dir: 'source/fsw'

--- a/config/default_hs_msg.h
+++ b/config/default_hs_msg.h
@@ -31,12 +31,6 @@
 #ifndef DEFAULT_HK_MSG_H
 #define DEFAULT_HK_MSG_H
 
-/************************************************************************
- * THIS IS RELATED TO THE DATA TYPE USED IN 'AppMonEnable' FIELD IN THE TLM STRUCTURE
- ************************************************************************/
-
-#define HS_BITS_PER_APPMON_ENABLE 32 /**< \brief HS Bits per AppMon Enable entry */
-
 #include "hs_interface_cfg.h"
 #include "hs_msgdefs.h"
 #include "hs_msgstruct.h"

--- a/config/default_hs_msgdefs.h
+++ b/config/default_hs_msgdefs.h
@@ -28,4 +28,16 @@
 
 #include "hs_fcncodes.h"
 
+/**
+ * Macro to set single enable bit in the standard TLM data structure
+ *
+ * Each entry is a single bit so it needs to be set via a bitmask
+ * The left-most bit should be the first entry (index 0)
+ */
+#define HS_SET_TLM_ENABLE_BITMASK(arr, p)    \
+    do                                       \
+    {                                        \
+        arr[(p) / 8] |= (0x80 >> ((p) % 8)); \
+    } while (0)
+
 #endif

--- a/config/default_hs_msgstruct.h
+++ b/config/default_hs_msgstruct.h
@@ -210,7 +210,7 @@ typedef struct
     uint32 EventsMonitoredCount;  /**< \brief Total count of Event Messages Monitored */
     uint32 InvalidEventMonCount;  /**< \brief Total count of Invalid Event Monitors */
 
-    uint32 AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) + 1];
+    uint8 AppMonEnables[(HS_MAX_MONITORED_APPS + 7) / 8];
     /**< \brief Enable states of App Monitor Entries */
 
     uint32 MsgActExec;  /**< \brief Number of Software Bus Message Actions Executed */

--- a/config/default_hs_tblstruct.h
+++ b/config/default_hs_tblstruct.h
@@ -88,8 +88,9 @@ typedef struct
  */
 typedef union
 {
-    uint8           Message[HS_MAX_MSG_ACT_SIZE]; /**< \brief Raw message array for sizing */
-    CFE_SB_Buffer_t Buffer;                       /**< \brief Message Buffer for alignment */
+    uint8         Message[HS_MAX_MSG_ACT_SIZE]; /**< \brief Raw message array for sizing */
+    long long int LongInt;                      /**< \brief Align to support Long Integer */
+    double        Dbl;                          /**< \brief Align to support Double */
 } HS_MATMsgBuf_t;
 
 /**

--- a/config/eds_hs_msgdefs.h
+++ b/config/eds_hs_msgdefs.h
@@ -29,4 +29,15 @@
 #include "hs_eds_typedefs.h"
 #include "hs_fcncodes.h"
 
+/**
+ * Macro to set single enable bit in the EDS data structure
+ *
+ * In EDS each entry gets its own bool so access is very simple
+ */
+#define HS_SET_TLM_ENABLE_BITMASK(arr, p) \
+    do                                    \
+    {                                     \
+        arr[p] = true;                    \
+    } while (0)
+
 #endif

--- a/fsw/src/hs_app.c
+++ b/fsw/src/hs_app.c
@@ -592,9 +592,10 @@ CFE_Status_t HS_TblInit(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 CFE_Status_t HS_ProcessMain(void)
 {
-    CFE_Status_t Status      = CFE_SUCCESS;
-    const char  *AliveString = HS_CPU_ALIVE_STRING;
-    uint32       i           = 0;
+    CFE_Status_t      Status      = CFE_SUCCESS;
+    const char       *AliveString = HS_CPU_ALIVE_STRING;
+    uint32            i           = 0;
+    HS_MsgActState_t *MAStatePtr;
 
     /*
     ** Get Tables
@@ -606,9 +607,11 @@ CFE_Status_t HS_ProcessMain(void)
     */
     for (i = 0; i < HS_MAX_MSG_ACT_TYPES; i++)
     {
-        if (HS_AppData.MsgActCooldown[i] != 0)
+        MAStatePtr = &HS_AppData.MsgActState[i];
+
+        if (MAStatePtr->Cooldown != 0)
         {
-            HS_AppData.MsgActCooldown[i]--;
+            --MAStatePtr->Cooldown;
         }
     }
 

--- a/fsw/src/hs_app.h
+++ b/fsw/src/hs_app.h
@@ -88,6 +88,18 @@ typedef struct
     uint16 MaxResetsNot;       /**< \brief Inverted Max Number of Resets Allowed for validation */
 } HS_CDSData_t;
 
+typedef struct
+{
+    bool   Enable;
+    uint16 CheckInCountdown; /**< \brief Counts until Application Monitor times out */
+    uint32 LastExeCount;     /**< \brief Last Execution Count for application being checked */
+} HS_AppMonState_t;
+
+typedef struct
+{
+    uint16 Cooldown; /**< \brief Counts until Message Actions is available */
+} HS_MsgActState_t;
+
 /**
  *  \brief HS Global Data Structure
  */
@@ -117,13 +129,8 @@ typedef struct
 
     uint32 EventsMonitoredCount; /**< \brief Total count of event messages monitored */
 
-    uint16 MsgActCooldown[HS_MAX_MSG_ACT_TYPES];          /**< \brief Counts until Message Actions is available */
-    uint16 AppMonCheckInCountdown[HS_MAX_MONITORED_APPS]; /**< \brief Counts until Application Monitor times out */
-
-    uint32 AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE)
-                         + 1]; /**< \brief AppMon state by monitor */
-
-    uint32 AppMonLastExeCount[HS_MAX_MONITORED_APPS]; /**< \brief Last Execution Count for application being checked */
+    HS_MsgActState_t MsgActState[HS_MAX_MSG_ACT_TYPES]; /**< \brief Counts until Message Actions is available */
+    HS_AppMonState_t AppMonState[HS_MAX_MONITORED_APPS];
 
     uint32 AlivenessCounter; /**< \brief Current Count towards the CPU Aliveness output period */
 
@@ -149,10 +156,9 @@ typedef struct
     CFE_TBL_Handle_t AMTableHandle; /**< \brief Apps Monitor table handle */
     CFE_TBL_Handle_t EMTableHandle; /**< \brief Events Monitor table handle */
     CFE_TBL_Handle_t MATableHandle; /**< \brief Message Actions table handle */
-
     CFE_TBL_Handle_t XCTableHandle; /**< \brief Execution Counters table handle */
-    HS_XCTEntry_t   *XCTablePtr;    /**< \brief Ptr to Execution Counters table entry */
 
+    HS_XCTEntry_t *XCTablePtr; /**< \brief Ptr to Execution Counters table entry */
     HS_AMTEntry_t *AMTablePtr; /**< \brief Ptr to Apps Monitor table entry */
     HS_EMTEntry_t *EMTablePtr; /**< \brief Ptr to Events Monitor table entry */
     HS_MATEntry_t *MATablePtr; /**< \brief Ptr to Message Actions table entry */
@@ -171,6 +177,72 @@ extern HS_AppData_t HS_AppData;
 /************************************************************************
  * Exported Functions
  ************************************************************************/
+
+static inline HS_AppMonState_t *HS_GetAMStateByIndex(uint32 TableIndex)
+{
+    return &HS_AppData.AppMonState[TableIndex];
+}
+
+static inline HS_MsgActState_t *HS_GetMAStateByIndex(uint32 TableIndex)
+{
+    return &HS_AppData.MsgActState[TableIndex];
+}
+
+static inline HS_AMTEntry_t *HS_GetAMTEntryByIndex(uint32 TableIndex)
+{
+    HS_AMTEntry_t *AMTEntryPtr;
+
+    AMTEntryPtr = HS_AppData.AMTablePtr;
+
+    if (AMTEntryPtr)
+    {
+        AMTEntryPtr += TableIndex;
+    }
+
+    return AMTEntryPtr;
+}
+
+static inline HS_EMTEntry_t *HS_GetEMTEntryByIndex(uint32 TableIndex)
+{
+    HS_EMTEntry_t *EMTEntryPtr;
+
+    EMTEntryPtr = HS_AppData.EMTablePtr;
+
+    if (EMTEntryPtr)
+    {
+        EMTEntryPtr += TableIndex;
+    }
+
+    return EMTEntryPtr;
+}
+
+static inline HS_MATEntry_t *HS_GetMATEntryByIndex(uint32 TableIndex)
+{
+    HS_MATEntry_t *MATEntryPtr;
+
+    MATEntryPtr = HS_AppData.MATablePtr;
+
+    if (MATEntryPtr)
+    {
+        MATEntryPtr += TableIndex;
+    }
+
+    return MATEntryPtr;
+}
+
+static inline HS_XCTEntry_t *HS_GetXCTEntryByIndex(uint32 TableIndex)
+{
+    HS_XCTEntry_t *XCTEntryPtr;
+
+    XCTEntryPtr = HS_AppData.XCTablePtr;
+
+    if (XCTEntryPtr)
+    {
+        XCTEntryPtr += TableIndex;
+    }
+
+    return XCTEntryPtr;
+}
 
 /**
  * \brief CFS Health and Safety (HS) application entry point

--- a/fsw/src/hs_cmds.c
+++ b/fsw/src/hs_cmds.c
@@ -57,6 +57,9 @@ CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
     uint32             TableIndex;
 
     HS_HkTlm_Payload_t *PayloadPtr;
+    HS_EMTEntry_t      *EMEntryPtr;
+    HS_XCTEntry_t      *XCEntryPtr;
+    HS_AppMonState_t   *AMStatePtr;
 
     memset(&TaskInfo, 0, sizeof(TaskInfo));
 
@@ -80,18 +83,17 @@ CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
     ** Calculate the current number of invalid event monitor entries
     */
     PayloadPtr->InvalidEventMonCount = 0;
-    if (HS_AppData.EMTablePtr != NULL)
+    for (TableIndex = 0; TableIndex < HS_MAX_MONITORED_EVENTS; TableIndex++)
     {
-        for (TableIndex = 0; TableIndex < HS_MAX_MONITORED_EVENTS; TableIndex++)
-        {
-            if (HS_AppData.EMTablePtr[TableIndex].ActionType != HS_EMTActType_NOACT)
-            {
-                Status = CFE_ES_GetAppIDByName(&AppId, HS_AppData.EMTablePtr[TableIndex].AppName);
+        EMEntryPtr = HS_GetEMTEntryByIndex(TableIndex);
 
-                if (Status != CFE_SUCCESS)
-                {
-                    PayloadPtr->InvalidEventMonCount++;
-                }
+        if (EMEntryPtr != NULL && EMEntryPtr->ActionType != HS_EMTActType_NOACT)
+        {
+            Status = CFE_ES_GetAppIDByName(&AppId, EMEntryPtr->AppName);
+
+            if (Status != CFE_SUCCESS)
+            {
+                PayloadPtr->InvalidEventMonCount++;
             }
         }
     }
@@ -124,9 +126,15 @@ CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
     /*
     ** Update the AppMon Enables
     */
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
+    memset(PayloadPtr->AppMonEnables, 0, sizeof(PayloadPtr->AppMonEnables));
+    for (TableIndex = 0; TableIndex < HS_MAX_MONITORED_APPS; TableIndex++)
     {
-        PayloadPtr->AppMonEnables[TableIndex] = HS_AppData.AppMonEnables[TableIndex];
+        AMStatePtr = HS_GetAMStateByIndex(TableIndex);
+
+        if (AMStatePtr->Enable)
+        {
+            HS_SET_TLM_ENABLE_BITMASK(PayloadPtr->AppMonEnables, TableIndex);
+        }
     }
 
     PayloadPtr->UtilCpuAvg  = HS_AppData.UtilCpuAvg;
@@ -137,15 +145,16 @@ CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
     */
     for (TableIndex = 0; TableIndex < HS_MAX_EXEC_CNT_SLOTS; TableIndex++)
     {
-        ExeCount = HS_INVALID_EXECOUNT;
+        XCEntryPtr = HS_GetXCTEntryByIndex(TableIndex);
+        ExeCount   = HS_INVALID_EXECOUNT;
 
-        if ((HS_AppData.ExeCountState == HS_State_ENABLED) && (HS_AppData.XCTablePtr != NULL))
+        if (XCEntryPtr != NULL && HS_AppData.ExeCountState == HS_State_ENABLED)
         {
-            switch (HS_AppData.XCTablePtr[TableIndex].ResourceType)
+            switch (XCEntryPtr->ResourceType)
             {
                 case HS_XCTResType_APP_MAIN:
                 case HS_XCTResType_APP_CHILD:
-                    Status = CFE_ES_GetTaskIDByName(&TaskId, HS_AppData.XCTablePtr[TableIndex].ResourceName);
+                    Status = CFE_ES_GetTaskIDByName(&TaskId, XCEntryPtr->ResourceName);
 
                     if (Status == CFE_SUCCESS)
                     {
@@ -158,7 +167,7 @@ CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
                     break;
                 case HS_XCTResType_DEVICE:
                 case HS_XCTResType_ISR:
-                    Status = CFE_ES_GetGenCounterIDByName(&CounterId, HS_AppData.XCTablePtr[TableIndex].ResourceName);
+                    Status = CFE_ES_GetGenCounterIDByName(&CounterId, XCEntryPtr->ResourceName);
 
                     if (Status == CFE_SUCCESS)
                     {
@@ -173,7 +182,7 @@ CFE_Status_t HS_SendHkCmd(const HS_SendHkCmd_t *BufPtr)
                     CFE_EVS_SendEvent(HS_HKREQ_RESOURCE_DBG_EID,
                                       CFE_EVS_EventType_DEBUG,
                                       "Housekeeping req found unknown resource.  Type=0x%08X",
-                                      (unsigned int)HS_AppData.XCTablePtr[TableIndex].ResourceType);
+                                      (unsigned int)XCEntryPtr->ResourceType);
                     break;
             } /* end ResourceType switch statement */
         } /* end ExeCountState if statement */
@@ -550,6 +559,7 @@ CFE_Status_t HS_SetMaxResetsCmd(const HS_SetMaxResetsCmd_t *BufPtr)
 void HS_AcquirePointers(void)
 {
     CFE_Status_t Status;
+    void        *TableTempPtr;
 
     /*
     ** Release the table (AppMon)
@@ -564,7 +574,7 @@ void HS_AcquirePointers(void)
     /*
     ** Get a pointer to the table (AppMon)
     */
-    Status = CFE_TBL_GetAddress((void *)&HS_AppData.AMTablePtr, HS_AppData.AMTableHandle);
+    Status = CFE_TBL_GetAddress(&TableTempPtr, HS_AppData.AMTableHandle);
 
     /*
     ** If there is a new table, refresh status (AppMon)
@@ -591,6 +601,8 @@ void HS_AcquirePointers(void)
             HS_AppData.CurrentAppMonState = HS_State_DISABLED;
             HS_AppData.AppMonLoaded       = HS_State_DISABLED;
         }
+
+        TableTempPtr = NULL;
     }
     /*
     ** Otherwise, mark that the table is loaded (AppMon)
@@ -599,6 +611,8 @@ void HS_AcquirePointers(void)
     {
         HS_AppData.AppMonLoaded = HS_State_ENABLED;
     }
+
+    HS_AppData.AMTablePtr = TableTempPtr;
 
     /*
     ** Release the table (EventMon)
@@ -613,7 +627,7 @@ void HS_AcquirePointers(void)
     /*
     ** Get a pointer to the table (EventMon)
     */
-    Status = CFE_TBL_GetAddress((void *)&HS_AppData.EMTablePtr, HS_AppData.EMTableHandle);
+    Status = CFE_TBL_GetAddress(&TableTempPtr, HS_AppData.EMTableHandle);
 
     /*
     ** If Address acquisition fails and currently enabled, report and disable (EventMon)
@@ -656,6 +670,8 @@ void HS_AcquirePointers(void)
             HS_AppData.CurrentEventMonState = HS_State_DISABLED;
             HS_AppData.EventMonLoaded       = HS_State_DISABLED;
         }
+
+        TableTempPtr = NULL;
     }
     /*
     ** Otherwise, mark that the table is loaded (EventMon)
@@ -664,6 +680,8 @@ void HS_AcquirePointers(void)
     {
         HS_AppData.EventMonLoaded = HS_State_ENABLED;
     }
+
+    HS_AppData.EMTablePtr = TableTempPtr;
 
     /*
     ** Release the table (MsgActs)
@@ -678,7 +696,7 @@ void HS_AcquirePointers(void)
     /*
     ** Get a pointer to the table (MsgActs)
     */
-    Status = CFE_TBL_GetAddress((void *)&HS_AppData.MATablePtr, HS_AppData.MATableHandle);
+    Status = CFE_TBL_GetAddress(&TableTempPtr, HS_AppData.MATableHandle);
 
     /*
     ** If there is a new table, refresh status (MsgActs)
@@ -704,6 +722,8 @@ void HS_AcquirePointers(void)
                               (unsigned int)Status);
             HS_AppData.MsgActsState = HS_State_DISABLED;
         }
+
+        TableTempPtr = NULL;
     }
     /*
     ** Otherwise, make sure it is enabled (MsgActs)
@@ -712,6 +732,8 @@ void HS_AcquirePointers(void)
     {
         HS_AppData.MsgActsState = HS_State_ENABLED;
     }
+
+    HS_AppData.MATablePtr = TableTempPtr;
 
     /*
     ** Release the table (ExeCount)
@@ -726,7 +748,7 @@ void HS_AcquirePointers(void)
     /*
     ** Get a pointer to the table (ExeCount)
     */
-    Status = CFE_TBL_GetAddress((void *)&HS_AppData.XCTablePtr, HS_AppData.XCTableHandle);
+    Status = CFE_TBL_GetAddress(&TableTempPtr, HS_AppData.XCTableHandle);
 
     /*
     ** If Address acquisition fails report and disable (ExeCount)
@@ -744,6 +766,8 @@ void HS_AcquirePointers(void)
                               (unsigned int)Status);
             HS_AppData.ExeCountState = HS_State_DISABLED;
         }
+
+        TableTempPtr = NULL;
     }
     /*
     ** Otherwise, make sure it is enabled (ExeCount)
@@ -752,6 +776,8 @@ void HS_AcquirePointers(void)
     {
         HS_AppData.ExeCountState = HS_State_ENABLED;
     }
+
+    HS_AppData.XCTablePtr = TableTempPtr;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -761,34 +787,29 @@ void HS_AcquirePointers(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_AppMonStatusRefresh(void)
 {
-    uint32 TableIndex  = 0;
-    uint32 EnableIndex = 0;
-
-    /*
-    ** Clear all AppMon Enable bits
-    */
-    for (EnableIndex = 0; EnableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); EnableIndex++)
-    {
-        HS_AppData.AppMonEnables[EnableIndex] = 0;
-    }
+    uint32            TableIndex;
+    HS_AMTEntry_t    *AMEntryPtr;
+    HS_AppMonState_t *AMStatePtr;
 
     /*
     ** Set AppMon enable bits and reset Countups and Exec Counter comparisons
     */
     for (TableIndex = 0; TableIndex < HS_MAX_MONITORED_APPS; TableIndex++)
     {
-        HS_AppData.AppMonLastExeCount[TableIndex] = 0;
+        AMEntryPtr = HS_GetAMTEntryByIndex(TableIndex);
+        AMStatePtr = HS_GetAMStateByIndex(TableIndex);
 
-        if ((HS_AppData.AMTablePtr[TableIndex].CycleCount == 0)
-            || (HS_AppData.AMTablePtr[TableIndex].ActionType == HS_AMTActType_NOACT))
+        AMStatePtr->LastExeCount = 0;
+
+        if (AMEntryPtr == NULL || AMEntryPtr->CycleCount == 0 || AMEntryPtr->ActionType == HS_AMTActType_NOACT)
         {
-            HS_AppData.AppMonCheckInCountdown[TableIndex] = 0;
+            AMStatePtr->CheckInCountdown = 0;
+            AMStatePtr->Enable           = false;
         }
         else
         {
-            HS_AppData.AppMonCheckInCountdown[TableIndex] = HS_AppData.AMTablePtr[TableIndex].CycleCount;
-            HS_AppData.AppMonEnables[TableIndex / HS_BITS_PER_APPMON_ENABLE] |=
-                (1 << (TableIndex % HS_BITS_PER_APPMON_ENABLE));
+            AMStatePtr->CheckInCountdown = AMEntryPtr->CycleCount;
+            AMStatePtr->Enable           = true;
         }
     }
 }
@@ -800,13 +821,16 @@ void HS_AppMonStatusRefresh(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_MsgActsStatusRefresh(void)
 {
-    uint32 TableIndex = 0;
+    uint32            TableIndex;
+    HS_MsgActState_t *MAStatePtr;
 
     /*
     ** Clear all MsgActs Cooldowns
     */
     for (TableIndex = 0; TableIndex < HS_MAX_MSG_ACT_TYPES; TableIndex++)
     {
-        HS_AppData.MsgActCooldown[TableIndex] = 0;
+        MAStatePtr = HS_GetMAStateByIndex(TableIndex);
+
+        MAStatePtr->Cooldown = 0;
     }
 }

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -131,9 +131,15 @@ void HS_MonitorSingleApplication(const HS_AMTEntry_t *AMEntryPtr, HS_AppMonState
     }
 
     /*
-    ** Failure to get an execution counter is not considered an automatic failure (or eventworthy)
+    ** If the app name did not resolve, do not count it as a missed check-in.
+    ** Only decrement the countdown when the app exists but has not executed.
     */
-    if ((Status == CFE_SUCCESS) && (AMStatePtr->LastExeCount != AppInfo.ExecutionCounter))
+    if (Status != CFE_SUCCESS)
+    {
+        return;
+    }
+
+    if (AMStatePtr->LastExeCount != AppInfo.ExecutionCounter)
     {
         /*
         ** Set the current count, and reset the timeout

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -37,364 +37,370 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Monitor Applications                                            */
+/* Helper function to implement cooldown logic for msg actions     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void HS_MonitorApplications(void)
+void HS_ExecuteMessageAction(uint16 ActionType, void (*SendEventCb)(uint32, const void *), const void *CbArg)
+{
+    uint32            MsgActsIndex;
+    HS_MATEntry_t    *MAEntryPtr;
+    HS_MsgActState_t *MAStatePtr;
+
+    /* Calculate the requested message action index */
+    MsgActsIndex = ActionType - HS_EMTActType_LAST_NONMSG - 1;
+
+    /*
+    ** Check to see if this is a valid Message Action Type
+    */
+    if (HS_AppData.MsgActsState == HS_State_ENABLED && MsgActsIndex < HS_MAX_MSG_ACT_TYPES)
+    {
+        MAEntryPtr = HS_GetMATEntryByIndex(MsgActsIndex);
+        MAStatePtr = HS_GetMAStateByIndex(MsgActsIndex);
+
+        /*
+        ** Send the message if off cooldown and not disabled
+        */
+        if (MAEntryPtr != NULL && MAStatePtr->Cooldown == 0 && MAEntryPtr->EnableState != HS_MATState_DISABLED)
+        {
+            CFE_SB_TransmitMsg((const CFE_MSG_Message_t *)&MAEntryPtr->MsgBuf, true);
+
+            HS_AppData.MsgActExec++;
+            MAStatePtr->Cooldown = MAEntryPtr->Cooldown;
+
+            /* Send the event via callback */
+            if (MAEntryPtr->EnableState != HS_MATState_NOEVENT)
+            {
+                SendEventCb(MsgActsIndex, CbArg);
+            }
+        }
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* App Monitor Callback/helper to send message action event        */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void HS_AppMonActCallback(uint32 MsgActsIndex, const void *Arg)
+{
+    const HS_AMTEntry_t *AMEntryPtr = Arg;
+
+    CFE_EVS_SendEvent(HS_APPMON_MSGACTS_ERR_EID,
+                      CFE_EVS_EventType_ERROR,
+                      "App Monitor Failure: APP:(%s): Action: Message Action Index: %d",
+                      AMEntryPtr->AppName,
+                      (int)MsgActsIndex);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Monitor Application (single)                                    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_MonitorSingleApplication(const HS_AMTEntry_t *AMEntryPtr, HS_AppMonState_t *AMStatePtr)
 {
     CFE_ES_AppInfo_t AppInfo;
     CFE_ES_AppId_t   AppId = CFE_ES_APPID_UNDEFINED;
     CFE_Status_t     Status;
-    uint32           TableIndex = 0;
-    uint16           ActionType;
-    uint32           MsgActsIndex = 0;
-
-    /* Avoid accessing AMT if table pointer is invalid */
-    if (HS_AppData.AMTablePtr == NULL)
-    {
-        return;
-    }
 
     memset(&AppInfo, 0, sizeof(AppInfo));
 
-    for (TableIndex = 0; TableIndex < HS_MAX_MONITORED_APPS; TableIndex++)
+    Status = CFE_ES_GetAppIDByName(&AppId, AMEntryPtr->AppName);
+
+    if (Status == CFE_SUCCESS)
     {
-        ActionType = HS_AppData.AMTablePtr[TableIndex].ActionType;
+        Status = CFE_ES_GetAppInfo(&AppInfo, AppId);
+    }
+    else if (AMStatePtr->CheckInCountdown == AMEntryPtr->CycleCount)
+    {
+        /*
+        ** Only send an error event the first time the App fails to resolve
+        */
+        CFE_EVS_SendEvent(HS_APPMON_APPNAME_ERR_EID,
+                          CFE_EVS_EventType_ERROR,
+                          "App Monitor App Name not found: APP:(%s)",
+                          AMEntryPtr->AppName);
+    }
+    else
+    {
+        /* For repeated errors, send a debug event */
+        CFE_EVS_SendEvent(HS_APPMON_APPNAME_DBG_EID,
+                          CFE_EVS_EventType_DEBUG,
+                          "App Monitor App Name not found: APP:(%s)",
+                          AMEntryPtr->AppName);
+    }
+
+    /*
+    ** Failure to get an execution counter is not considered an automatic failure (or eventworthy)
+    */
+    if ((Status == CFE_SUCCESS) && (AMStatePtr->LastExeCount != AppInfo.ExecutionCounter))
+    {
+        /*
+        ** Set the current count, and reset the timeout
+        */
+        AMStatePtr->CheckInCountdown = AMEntryPtr->CycleCount;
+        AMStatePtr->LastExeCount     = AppInfo.ExecutionCounter;
+    }
+    else
+    {
+        AMStatePtr->CheckInCountdown--;
 
         /*
-        ** Check this App if it has an action, and hasn't already expired
+        ** Take Action once the counter reaches zero
         */
-        if ((ActionType != HS_AMTActType_NOACT) && (HS_AppData.AppMonCheckInCountdown[TableIndex] != 0))
+        if (AMStatePtr->CheckInCountdown == 0)
         {
-            Status = CFE_ES_GetAppIDByName(&AppId, HS_AppData.AMTablePtr[TableIndex].AppName);
-
-            if (Status == CFE_SUCCESS)
-            {
-                Status = CFE_ES_GetAppInfo(&AppInfo, AppId);
-            }
-            else if (HS_AppData.AppMonCheckInCountdown[TableIndex] == HS_AppData.AMTablePtr[TableIndex].CycleCount)
-            {
-                /*
-                ** Only send an error event the first time the App fails to resolve
-                */
-                CFE_EVS_SendEvent(HS_APPMON_APPNAME_ERR_EID,
-                                  CFE_EVS_EventType_ERROR,
-                                  "App Monitor App Name not found: APP:(%s)",
-                                  HS_AppData.AMTablePtr[TableIndex].AppName);
-            }
-            else
-            {
-                /* For repeated errors, send a debug event */
-                CFE_EVS_SendEvent(HS_APPMON_APPNAME_DBG_EID,
-                                  CFE_EVS_EventType_DEBUG,
-                                  "App Monitor App Name not found: APP:(%s)",
-                                  HS_AppData.AMTablePtr[TableIndex].AppName);
-            }
-
             /*
-            ** Failure to get an execution counter is not considered an automatic failure (or eventworthy)
+            ** Unset the enabled bit flag
             */
-            if ((Status == CFE_SUCCESS) && (HS_AppData.AppMonLastExeCount[TableIndex] != AppInfo.ExecutionCounter))
-            {
-                /*
-                ** Set the current count, and reset the timeout
-                */
-                HS_AppData.AppMonCheckInCountdown[TableIndex] = HS_AppData.AMTablePtr[TableIndex].CycleCount;
-                HS_AppData.AppMonLastExeCount[TableIndex]     = AppInfo.ExecutionCounter;
-            }
-            else
-            {
-                HS_AppData.AppMonCheckInCountdown[TableIndex]--;
+            AMStatePtr->Enable = false;
 
-                /*
-                ** Take Action once the counter reaches zero
-                */
-                if (HS_AppData.AppMonCheckInCountdown[TableIndex] == 0)
-                {
+            switch (AMEntryPtr->ActionType)
+            {
+                case HS_AMTActType_PROC_RESET:
+                    CFE_EVS_SendEvent(HS_APPMON_PROC_ERR_EID,
+                                      CFE_EVS_EventType_ERROR,
+                                      "App Monitor Failure: APP:(%s): Action: Processor Reset",
+                                      AMEntryPtr->AppName);
+
                     /*
-                    ** Unset the enabled bit flag
+                    ** Perform a reset if we can
                     */
-                    HS_AppData.AppMonEnables[TableIndex / HS_BITS_PER_APPMON_ENABLE] &=
-                        ~(1 << (TableIndex % HS_BITS_PER_APPMON_ENABLE));
-                    switch (ActionType)
+                    if (HS_AppData.CDSData.ResetsPerformed < HS_AppData.CDSData.MaxResets)
                     {
-                        case HS_AMTActType_PROC_RESET:
-                            CFE_EVS_SendEvent(HS_APPMON_PROC_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "App Monitor Failure: APP:(%s): Action: Processor Reset",
-                                              HS_AppData.AMTablePtr[TableIndex].AppName);
+                        HS_SetCDSData((HS_AppData.CDSData.ResetsPerformed + 1), HS_AppData.CDSData.MaxResets);
 
-                            /*
-                            ** Perform a reset if we can
-                            */
-                            if (HS_AppData.CDSData.ResetsPerformed < HS_AppData.CDSData.MaxResets)
-                            {
-                                HS_SetCDSData((HS_AppData.CDSData.ResetsPerformed + 1), HS_AppData.CDSData.MaxResets);
+                        OS_TaskDelay(HS_RESET_TASK_DELAY);
+                        CFE_ES_WriteToSysLog("HS App: App Monitor Failure: APP:(%s): Action: Processor Reset\n",
+                                             AMEntryPtr->AppName);
+                        HS_AppData.ServiceWatchdogFlag = HS_State_DISABLED;
+                        CFE_ES_ResetCFE(CFE_PSP_RST_TYPE_PROCESSOR);
+                    }
+                    else
+                    {
+                        CFE_EVS_SendEvent(HS_RESET_LIMIT_ERR_EID,
+                                          CFE_EVS_EventType_ERROR,
+                                          "Processor Reset Action Limit Reached: No Reset Performed");
+                    }
 
-                                OS_TaskDelay(HS_RESET_TASK_DELAY);
-                                CFE_ES_WriteToSysLog("HS App: App Monitor Failure: APP:(%s): Action: Processor Reset\n",
-                                                     HS_AppData.AMTablePtr[TableIndex].AppName);
-                                HS_AppData.ServiceWatchdogFlag = HS_State_DISABLED;
-                                CFE_ES_ResetCFE(CFE_PSP_RST_TYPE_PROCESSOR);
-                            }
-                            else
-                            {
-                                CFE_EVS_SendEvent(HS_RESET_LIMIT_ERR_EID,
-                                                  CFE_EVS_EventType_ERROR,
-                                                  "Processor Reset Action Limit Reached: No Reset Performed");
-                            }
+                    break;
 
-                            break;
+                case HS_AMTActType_APP_RESTART:
+                    CFE_EVS_SendEvent(HS_APPMON_RESTART_ERR_EID,
+                                      CFE_EVS_EventType_ERROR,
+                                      "App Monitor Failure: APP:(%s) Action: Restart Application",
+                                      AMEntryPtr->AppName);
+                    /*
+                    ** Attempt to restart the App if we resolved the AppId
+                    */
+                    if (Status == CFE_SUCCESS)
+                    {
+                        Status = CFE_ES_RestartApp(AppId);
+                    }
 
-                        case HS_AMTActType_APP_RESTART:
-                            CFE_EVS_SendEvent(HS_APPMON_RESTART_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "App Monitor Failure: APP:(%s) Action: Restart Application",
-                                              HS_AppData.AMTablePtr[TableIndex].AppName);
-                            /*
-                            ** Attempt to restart the App if we resolved the AppId
-                            */
-                            if (Status == CFE_SUCCESS)
-                            {
-                                Status = CFE_ES_RestartApp(AppId);
-                            }
+                    /*
+                    ** Report an error; either no valid AppId, or RestartApp failed
+                    */
+                    if (Status != CFE_SUCCESS)
+                    {
+                        CFE_EVS_SendEvent(HS_APPMON_NOT_RESTARTED_ERR_EID,
+                                          CFE_EVS_EventType_ERROR,
+                                          "Call to Restart App Failed: APP:(%s) ERR: 0x%08X",
+                                          AMEntryPtr->AppName,
+                                          (unsigned int)Status);
+                    }
 
-                            /*
-                            ** Report an error; either no valid AppId, or RestartApp failed
-                            */
-                            if (Status != CFE_SUCCESS)
-                            {
-                                CFE_EVS_SendEvent(HS_APPMON_NOT_RESTARTED_ERR_EID,
-                                                  CFE_EVS_EventType_ERROR,
-                                                  "Call to Restart App Failed: APP:(%s) ERR: 0x%08X",
-                                                  HS_AppData.AMTablePtr[TableIndex].AppName,
-                                                  (unsigned int)Status);
-                            }
+                    break;
 
-                            break;
+                case HS_AMTActType_EVENT:
+                    CFE_EVS_SendEvent(HS_APPMON_FAIL_ERR_EID,
+                                      CFE_EVS_EventType_ERROR,
+                                      "App Monitor Failure: APP:(%s): Action: Event Only",
+                                      AMEntryPtr->AppName);
+                    break;
 
-                        case HS_AMTActType_EVENT:
-                            CFE_EVS_SendEvent(HS_APPMON_FAIL_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "App Monitor Failure: APP:(%s): Action: Event Only",
-                                              HS_AppData.AMTablePtr[TableIndex].AppName);
-                            break;
+                /*
+                ** Message Action types processing (invalid will be skipped)
+                */
+                default:
+                    HS_ExecuteMessageAction(AMEntryPtr->ActionType, HS_AppMonActCallback, AMEntryPtr);
+                    break;
+            } /* end switch */
 
-                        /*
-                        ** Message Action types processing (invalid will be skipped)
-                        */
-                        default:
+        } /* end (AMStatePtr->CheckInCountdown == 0) if */
+    }
+}
 
-                            /* Calculate the requested message action index */
-                            MsgActsIndex = ActionType - HS_AMTActType_LAST_NONMSG - 1;
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Monitor Applications (global)                                   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_MonitorApplications(void)
+{
+    uint32            TableIndex;
+    HS_AMTEntry_t    *AMEntryPtr;
+    HS_AppMonState_t *AMStatePtr;
 
-                            /*
-                            ** Check to see if this is a valid Message Action Type
-                            */
-                            if ((HS_AppData.MsgActsState == HS_State_ENABLED) && (MsgActsIndex < HS_MAX_MSG_ACT_TYPES))
-                            {
-                                /*
-                                ** Send the message if off cooldown and not disabled
-                                */
-                                if ((HS_AppData.MsgActCooldown[MsgActsIndex] == 0)
-                                    && (HS_AppData.MATablePtr[MsgActsIndex].EnableState != HS_MATState_DISABLED))
-                                {
-                                    CFE_SB_TransmitMsg(
-                                        (const CFE_MSG_Message_t *)&HS_AppData.MATablePtr[MsgActsIndex].MsgBuf,
-                                        true);
-                                    HS_AppData.MsgActExec++;
-                                    HS_AppData.MsgActCooldown[MsgActsIndex] =
-                                        HS_AppData.MATablePtr[MsgActsIndex].Cooldown;
-                                    if (HS_AppData.MATablePtr[MsgActsIndex].EnableState != HS_MATState_NOEVENT)
-                                    {
-                                        CFE_EVS_SendEvent(
-                                            HS_APPMON_MSGACTS_ERR_EID,
-                                            CFE_EVS_EventType_ERROR,
-                                            "App Monitor Failure: APP:(%s): Action: Message Action Index: %d",
-                                            HS_AppData.AMTablePtr[TableIndex].AppName,
-                                            (int)MsgActsIndex);
-                                    }
-                                }
-                            }
+    for (TableIndex = 0; TableIndex < HS_MAX_MONITORED_APPS; TableIndex++)
+    {
+        AMEntryPtr = HS_GetAMTEntryByIndex(TableIndex);
+        AMStatePtr = HS_GetAMStateByIndex(TableIndex);
 
-                            /* Otherwise, Take No Action */
-                            break;
-                    } /* end switch */
-
-                } /* end (HS_AppData.AppMonCheckInCountdown[TableIndex] == 0) if */
-
-            } /* end "failed to update counter" else */
-
-        } /* end (HS_AppData.AppMonCheckInCountdown[TableIndex] != 0) if */
+        if (AMEntryPtr != NULL && AMEntryPtr->ActionType != HS_AMTActType_NOACT && AMStatePtr->CheckInCountdown != 0)
+        {
+            HS_MonitorSingleApplication(AMEntryPtr, AMStatePtr);
+        }
 
     } /* end for loop */
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Monitor Events                                                  */
+/* Event Monitor Callback/helper to send message action event      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void HS_EventMonActCallback(uint32 MsgActsIndex, const void *Arg)
+{
+    const HS_EMTEntry_t *EMEntryPtr = Arg;
+
+    CFE_EVS_SendEvent(HS_EVENTMON_MSGACTS_ERR_EID,
+                      CFE_EVS_EventType_ERROR,
+                      "Event Monitor: APP:(%s) EID:(%d): Action: Message Action Index: %d",
+                      EMEntryPtr->AppName,
+                      EMEntryPtr->EventID,
+                      (int)MsgActsIndex);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Monitor Events (single)                                         */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HS_MonitorSingleEvent(const HS_EMTEntry_t *EMEntryPtr)
+{
+    CFE_Status_t   Status = CFE_SUCCESS;
+    CFE_ES_AppId_t AppId  = CFE_ES_APPID_UNDEFINED;
+
+    /*
+    ** Perform the action if the strings also match
+    */
+    switch (EMEntryPtr->ActionType)
+    {
+        case HS_EMTActType_PROC_RESET:
+            CFE_EVS_SendEvent(HS_EVENTMON_PROC_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "Event Monitor: APP:(%s) EID:(%d): Action: Processor Reset",
+                              EMEntryPtr->AppName,
+                              EMEntryPtr->EventID);
+
+            /*
+            ** Perform a reset if we can
+            */
+            if (HS_AppData.CDSData.ResetsPerformed < HS_AppData.CDSData.MaxResets)
+            {
+                HS_SetCDSData((HS_AppData.CDSData.ResetsPerformed + 1), HS_AppData.CDSData.MaxResets);
+
+                OS_TaskDelay(HS_RESET_TASK_DELAY);
+                CFE_ES_WriteToSysLog("HS App: Event Monitor: APP:(%s) EID:(%d): Action: Processor Reset\n",
+                                     EMEntryPtr->AppName,
+                                     (int)EMEntryPtr->EventID);
+                HS_AppData.ServiceWatchdogFlag = HS_State_DISABLED;
+                CFE_ES_ResetCFE(CFE_PSP_RST_TYPE_PROCESSOR);
+            }
+            else
+            {
+                CFE_EVS_SendEvent(HS_RESET_LIMIT_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "Processor Reset Action Limit Reached: No Reset Performed");
+            }
+
+            break;
+
+        case HS_EMTActType_APP_RESTART:
+            /*
+            ** Check to see if the App is still there, and try to restart if it is
+            */
+            Status = CFE_ES_GetAppIDByName(&AppId, EMEntryPtr->AppName);
+            if (Status == CFE_SUCCESS)
+            {
+                CFE_EVS_SendEvent(HS_EVENTMON_RESTART_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "Event Monitor: APP:(%s) EID:(%d): Action: Restart Application",
+                                  EMEntryPtr->AppName,
+                                  EMEntryPtr->EventID);
+                Status = CFE_ES_RestartApp(AppId);
+            }
+
+            if (Status != CFE_SUCCESS)
+            {
+                CFE_EVS_SendEvent(HS_EVENTMON_NOT_RESTARTED_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "Call to Restart App Failed: APP:(%s) ERR: 0x%08X",
+                                  EMEntryPtr->AppName,
+                                  (unsigned int)Status);
+            }
+
+            break;
+
+        case HS_EMTActType_APP_DELETE:
+            /*
+            ** Check to see if the App is still there, and try to delete if it is
+            */
+            Status = CFE_ES_GetAppIDByName(&AppId, EMEntryPtr->AppName);
+            if (Status == CFE_SUCCESS)
+            {
+                CFE_EVS_SendEvent(HS_EVENTMON_DELETE_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "Event Monitor: APP:(%s) EID:(%d): Action: Delete Application",
+                                  EMEntryPtr->AppName,
+                                  EMEntryPtr->EventID);
+                Status = CFE_ES_DeleteApp(AppId);
+            }
+
+            if (Status != CFE_SUCCESS)
+            {
+                CFE_EVS_SendEvent(HS_EVENTMON_NOT_DELETED_ERR_EID,
+                                  CFE_EVS_EventType_ERROR,
+                                  "Call to Delete App Failed: APP:(%s) ERR: 0x%08X",
+                                  EMEntryPtr->AppName,
+                                  (unsigned int)Status);
+            }
+
+            break;
+
+        /*
+        ** Message Action types processing (invalid will be skipped)
+        */
+        default:
+            HS_ExecuteMessageAction(EMEntryPtr->ActionType, HS_EventMonActCallback, EMEntryPtr);
+            break;
+    } /* end switch */
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Monitor Events (global)                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HS_MonitorEvent(const CFE_EVS_LongEventTlm_t *EventPtr)
 {
-    uint32           TableIndex = 0;
-    CFE_Status_t     Status     = CFE_SUCCESS;
-    CFE_ES_AppId_t   AppId      = CFE_ES_APPID_UNDEFINED;
-    uint16           ActionType;
-    uint32           MsgActsIndex = 0;
-    CFE_SB_Buffer_t *SendPtr      = NULL;
-
-    /* Avoid accessing EMT if table pointer is invalid */
-    if (HS_AppData.EMTablePtr == NULL)
-    {
-        return;
-    }
+    uint32         TableIndex = 0;
+    HS_EMTEntry_t *EMEntryPtr;
 
     for (TableIndex = 0; TableIndex < HS_MAX_MONITORED_EVENTS; TableIndex++)
     {
-        ActionType = HS_AppData.EMTablePtr[TableIndex].ActionType;
+        EMEntryPtr = HS_GetEMTEntryByIndex(TableIndex);
 
         /*
         ** Check this Event Monitor if it has an action, and the event IDs match
         */
-        if ((ActionType != HS_EMTActType_NOACT)
-            && (HS_AppData.EMTablePtr[TableIndex].EventID == EventPtr->Payload.PacketID.EventID))
+        if (EMEntryPtr != NULL && EMEntryPtr->ActionType != HS_EMTActType_NOACT
+            && EMEntryPtr->EventID == EventPtr->Payload.PacketID.EventID
+            && strncmp(EMEntryPtr->AppName, EventPtr->Payload.PacketID.AppName, sizeof(EMEntryPtr->AppName)) == 0)
         {
-            if (strncmp(HS_AppData.EMTablePtr[TableIndex].AppName, EventPtr->Payload.PacketID.AppName, OS_MAX_API_NAME)
-                == 0)
-            {
-                /*
-                ** Perform the action if the strings also match
-                */
-                switch (ActionType)
-                {
-                    case HS_EMTActType_PROC_RESET:
-                        CFE_EVS_SendEvent(HS_EVENTMON_PROC_ERR_EID,
-                                          CFE_EVS_EventType_ERROR,
-                                          "Event Monitor: APP:(%s) EID:(%d): Action: Processor Reset",
-                                          HS_AppData.EMTablePtr[TableIndex].AppName,
-                                          HS_AppData.EMTablePtr[TableIndex].EventID);
-
-                        /*
-                        ** Perform a reset if we can
-                        */
-                        if (HS_AppData.CDSData.ResetsPerformed < HS_AppData.CDSData.MaxResets)
-                        {
-                            HS_SetCDSData((HS_AppData.CDSData.ResetsPerformed + 1), HS_AppData.CDSData.MaxResets);
-
-                            OS_TaskDelay(HS_RESET_TASK_DELAY);
-                            CFE_ES_WriteToSysLog("HS App: Event Monitor: APP:(%s) EID:(%d): Action: Processor Reset\n",
-                                                 HS_AppData.EMTablePtr[TableIndex].AppName,
-                                                 (int)HS_AppData.EMTablePtr[TableIndex].EventID);
-                            HS_AppData.ServiceWatchdogFlag = HS_State_DISABLED;
-                            CFE_ES_ResetCFE(CFE_PSP_RST_TYPE_PROCESSOR);
-                        }
-                        else
-                        {
-                            CFE_EVS_SendEvent(HS_RESET_LIMIT_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "Processor Reset Action Limit Reached: No Reset Performed");
-                        }
-
-                        break;
-
-                    case HS_EMTActType_APP_RESTART:
-                        /*
-                        ** Check to see if the App is still there, and try to restart if it is
-                        */
-                        Status = CFE_ES_GetAppIDByName(&AppId, HS_AppData.EMTablePtr[TableIndex].AppName);
-                        if (Status == CFE_SUCCESS)
-                        {
-                            CFE_EVS_SendEvent(HS_EVENTMON_RESTART_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "Event Monitor: APP:(%s) EID:(%d): Action: Restart Application",
-                                              HS_AppData.EMTablePtr[TableIndex].AppName,
-                                              HS_AppData.EMTablePtr[TableIndex].EventID);
-                            Status = CFE_ES_RestartApp(AppId);
-                        }
-
-                        if (Status != CFE_SUCCESS)
-                        {
-                            CFE_EVS_SendEvent(HS_EVENTMON_NOT_RESTARTED_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "Call to Restart App Failed: APP:(%s) ERR: 0x%08X",
-                                              HS_AppData.EMTablePtr[TableIndex].AppName,
-                                              (unsigned int)Status);
-                        }
-
-                        break;
-
-                    case HS_EMTActType_APP_DELETE:
-                        /*
-                        ** Check to see if the App is still there, and try to delete if it is
-                        */
-                        Status = CFE_ES_GetAppIDByName(&AppId, HS_AppData.EMTablePtr[TableIndex].AppName);
-                        if (Status == CFE_SUCCESS)
-                        {
-                            CFE_EVS_SendEvent(HS_EVENTMON_DELETE_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "Event Monitor: APP:(%s) EID:(%d): Action: Delete Application",
-                                              HS_AppData.EMTablePtr[TableIndex].AppName,
-                                              HS_AppData.EMTablePtr[TableIndex].EventID);
-                            Status = CFE_ES_DeleteApp(AppId);
-                        }
-
-                        if (Status != CFE_SUCCESS)
-                        {
-                            CFE_EVS_SendEvent(HS_EVENTMON_NOT_DELETED_ERR_EID,
-                                              CFE_EVS_EventType_ERROR,
-                                              "Call to Delete App Failed: APP:(%s) ERR: 0x%08X",
-                                              HS_AppData.EMTablePtr[TableIndex].AppName,
-                                              (unsigned int)Status);
-                        }
-
-                        break;
-
-                    /*
-                    ** Message Action types processing (invalid will be skipped)
-                    */
-                    default:
-
-                        /* Calculate the requested message action index */
-                        MsgActsIndex = ActionType - HS_EMTActType_LAST_NONMSG - 1;
-
-                        /*
-                        ** Check to see if this is a valid Message Action Type
-                        */
-                        if ((HS_AppData.MsgActsState == HS_State_ENABLED) && (MsgActsIndex < HS_MAX_MSG_ACT_TYPES))
-                        {
-                            /*
-                            ** Send the message if off cooldown and not disabled
-                            */
-                            if ((HS_AppData.MsgActCooldown[MsgActsIndex] == 0)
-                                && (HS_AppData.MATablePtr[MsgActsIndex].EnableState != HS_MATState_DISABLED))
-                            {
-                                SendPtr = (CFE_SB_Buffer_t *)&HS_AppData.MATablePtr[MsgActsIndex].MsgBuf;
-                                CFE_SB_TransmitMsg(&SendPtr->Msg, true);
-
-                                HS_AppData.MsgActExec++;
-                                HS_AppData.MsgActCooldown[MsgActsIndex] = HS_AppData.MATablePtr[MsgActsIndex].Cooldown;
-                                if (HS_AppData.MATablePtr[MsgActsIndex].EnableState != HS_MATState_NOEVENT)
-                                {
-                                    CFE_EVS_SendEvent(
-                                        HS_EVENTMON_MSGACTS_ERR_EID,
-                                        CFE_EVS_EventType_ERROR,
-                                        "Event Monitor: APP:(%s) EID:(%d): Action: Message Action Index: %d",
-                                        HS_AppData.EMTablePtr[TableIndex].AppName,
-                                        HS_AppData.EMTablePtr[TableIndex].EventID,
-                                        (int)MsgActsIndex);
-                                }
-                            }
-                        }
-
-                        /* Otherwise, Take No Action */
-                        break;
-                } /* end switch */
-
-            } /* end AppName comparison */
-
-        } /* end EventID comparison */
-
+            HS_MonitorSingleEvent(EMEntryPtr);
+        }
     } /* end for loop */
 }
 

--- a/unit-test/hs_app_tests.c
+++ b/unit-test/hs_app_tests.c
@@ -1759,9 +1759,9 @@ void HS_ProcessMain_Test(void)
     /* Causes HS_ProcessCommands to return CFE_SUCCESS, which is then returned from HS_ProcessMain */
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_NO_MESSAGE);
 
-    HS_AppData.MsgActCooldown[0]                        = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] = 2;
+    HS_AppData.MsgActState[0].Cooldown                        = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown = 2;
 
     HS_AppData.CurrentAppMonState    = HS_State_ENABLED;
     HS_AppData.CurrentAlivenessState = HS_State_ENABLED;
@@ -1775,11 +1775,11 @@ void HS_ProcessMain_Test(void)
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 1, "HS_AppData.MsgActCooldown[0] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 1, "HS_AppData.MsgActState[0].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1");
     UtAssert_True(HS_AppData.AlivenessCounter == 0, "HS_AppData.AlivenessCounter == 0");
 
     /* Ensure the watchdog was serviced when flag is HS_State_ENABLED */
@@ -1806,9 +1806,9 @@ void HS_ProcessMain_Test_MonStateDisabled(void)
     /* Causes HS_ProcessCommands to return CFE_SUCCESS, which is then returned from HS_ProcessMain */
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_NO_MESSAGE);
 
-    HS_AppData.MsgActCooldown[0]                        = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] = 2;
+    HS_AppData.MsgActState[0].Cooldown                        = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown = 2;
 
     HS_AppData.CurrentAppMonState    = HS_State_ENABLED;
     HS_AppData.CurrentAlivenessState = HS_State_ENABLED;
@@ -1825,11 +1825,11 @@ void HS_ProcessMain_Test_MonStateDisabled(void)
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 1, "HS_AppData.MsgActCooldown[0] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 1, "HS_AppData.MsgActState[0].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1");
     UtAssert_True(HS_AppData.AlivenessCounter == 0, "HS_AppData.AlivenessCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -1853,9 +1853,9 @@ void HS_ProcessMain_Test_AlivenessDisabled(void)
     /* Causes HS_ProcessCommands to return CFE_SUCCESS, which is then returned from HS_ProcessMain */
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_NO_MESSAGE);
 
-    HS_AppData.MsgActCooldown[0]                        = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] = 2;
+    HS_AppData.MsgActState[0].Cooldown                        = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown = 2;
 
     HS_AppData.CurrentAppMonState    = HS_State_ENABLED;
     HS_AppData.CurrentAlivenessState = HS_State_ENABLED;
@@ -1870,11 +1870,11 @@ void HS_ProcessMain_Test_AlivenessDisabled(void)
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 1, "HS_AppData.MsgActCooldown[0] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 1, "HS_AppData.MsgActState[0].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1");
     UtAssert_True(HS_AppData.AlivenessCounter == HS_CPU_ALIVE_PERIOD,
                   "HS_AppData.AlivenessCounter == HS_CPU_ALIVE_PERIOD");
 
@@ -1899,9 +1899,9 @@ void HS_ProcessMain_Test_WatchdogDisabled(void)
     /* Causes HS_ProcessCommands to return CFE_SUCCESS, which is then returned from HS_ProcessMain */
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SB_NO_MESSAGE);
 
-    HS_AppData.MsgActCooldown[0]                        = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] = 2;
-    HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] = 2;
+    HS_AppData.MsgActState[0].Cooldown                        = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown = 2;
+    HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown = 2;
 
     HS_AppData.CurrentAppMonState    = HS_State_ENABLED;
     HS_AppData.CurrentAlivenessState = HS_State_ENABLED;
@@ -1917,11 +1917,11 @@ void HS_ProcessMain_Test_WatchdogDisabled(void)
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 1, "HS_AppData.MsgActCooldown[0] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1,
-                  "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 1");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 1, "HS_AppData.MsgActState[0].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES / 2].Cooldown == 1");
+    UtAssert_True(HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1,
+                  "HS_AppData.MsgActState[HS_MAX_MSG_ACT_TYPES - 1].Cooldown == 1");
     UtAssert_True(HS_AppData.AlivenessCounter == 0, "HS_AppData.AlivenessCounter == 0");
 
     /* Ensure the watchdog was not serviced when flag is HS_State_DISABLED */

--- a/unit-test/hs_app_tests.c
+++ b/unit-test/hs_app_tests.c
@@ -47,7 +47,6 @@ typedef struct
 /* hs_app_tests globals */
 uint8 call_count_CFE_EVS_SendEvent;
 
-uint16 HS_APP_TEST_CFE_SB_RcvMsgHookCount;
 uint32 UT_WaitForStartupSyncTimeout;
 
 void UT_UpdatedDefaultHandler_CFE_SB_ReceiveBuffer(void                   *UserObj,
@@ -55,33 +54,6 @@ void UT_UpdatedDefaultHandler_CFE_SB_ReceiveBuffer(void                   *UserO
                                                    const UT_StubContext_t *Context)
 {
     CFE_SB_Buffer_t **BufPtr = UT_Hook_GetArgValueByName(Context, "BufPtr", CFE_SB_Buffer_t **);
-    UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ReceiveBuffer), BufPtr, sizeof(*BufPtr));
-}
-
-int32 HS_APP_TEST_CFE_SB_RcvMsgHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
-{
-    HS_APP_TEST_CFE_SB_RcvMsgHookCount++;
-
-    if (HS_APP_TEST_CFE_SB_RcvMsgHookCount % 2 == 1)
-        return CFE_SUCCESS;
-    else
-        return CFE_SB_NO_MESSAGE;
-}
-
-void HS_APP_TEST_CFE_RcvBufferHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
-{
-    CFE_SB_Buffer_t **BufPtr = UT_Hook_GetArgValueByName(Context, "BufPtr", CFE_SB_Buffer_t **);
-
-    CFE_Status_t status;
-    HS_APP_TEST_CFE_SB_RcvMsgHookCount++;
-
-    if (HS_APP_TEST_CFE_SB_RcvMsgHookCount % 2 == 1)
-        status = CFE_SUCCESS;
-    else
-        status = CFE_SB_NO_MESSAGE;
-
-    UT_Stub_GetInt32StatusCode(Context, &status);
-
     UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ReceiveBuffer), BufPtr, sizeof(*BufPtr));
 }
 
@@ -1955,7 +1927,6 @@ void HS_ProcessCommands_Test(void)
     }
 
     /* Causes CFE_SB_RcvMsg to alternate returning CFE_SUCCESS and CFE_SB_NO_MESSAGE, to reach all code branches. */
-    HS_APP_TEST_CFE_SB_RcvMsgHookCount = 0;
     CFE_SB_Buffer_t *dummy_BufPtr[4];
     CFE_SB_Buffer_t  dummy_Buf[4];
     dummy_BufPtr[0] = &dummy_Buf[0];
@@ -1967,10 +1938,6 @@ void HS_ProcessCommands_Test(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_ReceiveBuffer), CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 2, CFE_SB_NO_MESSAGE);
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 2, CFE_SB_NO_MESSAGE);
-    /* UT_SetHookFunction(UT_KEY(CFE_SB_ReceiveBuffer), HS_APP_TEST_CFE_SB_RcvMsgHook, NULL); */
-
-    /* Causes check for non-null buffer pointer to succeed */
-    /* UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), &Packet, sizeof(Packet), false); */
 
     /* Execute the function being tested */
     Result = HS_ProcessCommands();

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -2436,46 +2436,6 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoS
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
 }
 
-void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoSubscribeError2(void)
-{
-    HS_AppData.AppMonLoaded         = HS_State_DISABLED;
-    HS_AppData.EventMonLoaded       = HS_State_DISABLED;
-    HS_AppData.CurrentAppMonState   = HS_State_ENABLED;
-    HS_AppData.CurrentEventMonState = HS_State_DISABLED;
-    HS_AppData.MsgActsState         = HS_State_ENABLED;
-    HS_AppData.ExeCountState        = HS_State_ENABLED;
-
-    /* Causes to enter all (Status < CFE_SUCCESS) blocks */
-    UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), -1);
-
-    /* Causes event message HS_BADEMT_UNSUB_EID to not be generated */
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Unsubscribe), 2, -1);
-
-    /* Execute the function being tested */
-    HS_AcquirePointers();
-
-    /* Verify results */
-    UtAssert_True(HS_AppData.CurrentAppMonState == HS_State_DISABLED,
-                  "HS_AppData.CurrentAppMonState == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.AppMonLoaded == HS_State_DISABLED, "HS_AppData.AppMonLoaded == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.CurrentEventMonState == HS_State_DISABLED,
-                  "HS_AppData.CurrentEventMonState == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.EventMonLoaded == HS_State_DISABLED, "HS_AppData.EventMonLoaded == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.MsgActsState == HS_State_DISABLED, "HS_AppData.MsgActsState == HS_State_DISABLED");
-    UtAssert_True(HS_AppData.ExeCountState == HS_State_DISABLED, "HS_AppData.ExeCountState == HS_State_DISABLED");
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_GETADDR_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, HS_MSGACTS_GETADDR_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, HS_EXECOUNT_GETADDR_ERR_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventType, CFE_EVS_EventType_ERROR);
-
-    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
-}
-
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppMonStateDisabled(void)
 {
     HS_AppData.AppMonLoaded         = HS_State_DISABLED;

--- a/unit-test/hs_cmds_tests.c
+++ b/unit-test/hs_cmds_tests.c
@@ -34,10 +34,6 @@
 #include "cfe.h"
 #include "cfe_msgids.h"
 
-/* hs_cmds_tests globals */
-uint8 call_count_CFE_EVS_SendEvent;
-uint8 call_count_CFE_ES_GetAppIDByName;
-
 /*
  * Function Definitions
  */
@@ -56,12 +52,11 @@ int32 HS_CMDS_TEST_CFE_ES_GetTaskInfoHook(void                   *UserObj,
 
 void HS_SendHkCmd_Test_InvalidEventMon(void)
 {
-    CFE_SB_MsgId_t    TestMsgId;
-    CFE_MSG_FcnCode_t FcnCode;
-    size_t            MsgSize;
-    HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
-    uint32            TableIndex;
-
+    CFE_SB_MsgId_t      TestMsgId;
+    CFE_MSG_FcnCode_t   FcnCode;
+    size_t              MsgSize;
+    HS_EMTEntry_t       EMTable[HS_MAX_MONITORED_EVENTS];
+    HS_AppMonState_t   *AMStatePtr;
     HS_HkTlm_Payload_t *PayloadPtr;
 
     memset(EMTable, 0, sizeof(EMTable));
@@ -93,10 +88,13 @@ void HS_SendHkCmd_Test_InvalidEventMon(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     /* Execute the function being tested */
     HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
@@ -116,22 +114,16 @@ void HS_SendHkCmd_Test_InvalidEventMon(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 1, "PayloadPtr->InvalidEventMonCount == 1");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_NullEventMonTable(void)
@@ -139,7 +131,7 @@ void HS_SendHkCmd_Test_NullEventMonTable(void)
     CFE_SB_MsgId_t      TestMsgId;
     CFE_MSG_FcnCode_t   FcnCode;
     size_t              MsgSize;
-    uint32              TableIndex;
+    HS_AppMonState_t   *AMStatePtr;
     HS_HkTlm_Payload_t *PayloadPtr;
 
     /* setting this to null should prevent UUT from incrementing InvalidEventMonCount */
@@ -168,10 +160,13 @@ void HS_SendHkCmd_Test_NullEventMonTable(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     /* Execute the function being tested */
     HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
@@ -193,17 +188,17 @@ void HS_SendHkCmd_Test_NullEventMonTable(void)
     UtAssert_UINT32_EQ(PayloadPtr->InvalidEventMonCount, 0);
 
     /* Check first, middle, and last element */
-    UtAssert_UINT32_EQ(PayloadPtr->AppMonEnables[0], 0);
-    UtAssert_UINT32_EQ(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2],
-                       ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2);
-    UtAssert_UINT32_EQ(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE],
-                       (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE);
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_UINT8_EQ(call_count_CFE_EVS_SendEvent, 0);
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    call_count_CFE_ES_GetAppIDByName = UT_GetStubCount(UT_KEY(CFE_ES_GetAppIDByName));
-    UtAssert_UINT8_EQ(call_count_CFE_ES_GetAppIDByName, 0);
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+    UtAssert_STUB_COUNT(CFE_ES_GetAppIDByName, 0);
 }
 
 void HS_SendHkCmd_Test_AllFlagsEnabled(void)
@@ -215,6 +210,7 @@ void HS_SendHkCmd_Test_AllFlagsEnabled(void)
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint8             ExpectedStatusFlags = 0;
     int               i;
+    HS_AppMonState_t *AMStatePtr;
 
     HS_HkTlm_Payload_t *PayloadPtr;
 
@@ -281,22 +277,16 @@ void HS_SendHkCmd_Test_AllFlagsEnabled(void)
     UtAssert_True(PayloadPtr->StatusFlags == ExpectedStatusFlags, "PayloadPtr->StatusFlags == ExpectedStatusFlags");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_XCTablePtrNull(void)
@@ -360,6 +350,45 @@ void HS_SendHkCmd_Test_XCTablePtrNullAndDisabled(void)
     UtAssert_UINT32_EQ(UT_GetStubCount(UT_KEY(CFE_ES_GetTaskInfo)), 0);
 }
 
+void HS_SendHkCmd_Test_XCTablePtrNotNullAndDisabled(void)
+{
+    HS_XCTEntry_t XCTable[HS_MAX_EXEC_CNT_SLOTS];
+    int           i;
+
+    memset(XCTable, 0, sizeof(XCTable));
+
+    for (i = 0; i < HS_MAX_EXEC_CNT_SLOTS; i++)
+    {
+        XCTable[i].ResourceType = HS_XCTResType_APP_MAIN;
+    }
+
+    /*
+    ** initialize app data to inject error scenario
+    ** normally, XCTablePtr gets iniitalized during the table load (at app init)
+    ** and when that's success
+    */
+    HS_AppData.XCTablePtr    = XCTable;
+    HS_AppData.ExeCountState = HS_State_DISABLED;
+
+    /* Execute the function being tested */
+    HS_SendHkCmd(&UT_CmdBuf.SendHkCmd);
+
+    /*
+    ** Check that each Execution Counter was set to invalid,
+    ** since the XCT pointer was null
+    ** If the expected UUT lines weren't executed,
+    ** these values would likely be zero from the test case setup
+    */
+    for (i = 0; i < HS_MAX_EXEC_CNT_SLOTS; i++)
+    {
+        UtAssert_UINT32_EQ(HS_AppData.HkPacket.Payload.ExeCounts[i], HS_INVALID_EXECOUNT);
+    }
+
+    /* Check that these stubs weren't called */
+    UtAssert_UINT32_EQ(UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent)), 0);
+    UtAssert_UINT32_EQ(UT_GetStubCount(UT_KEY(CFE_ES_GetTaskInfo)), 0);
+}
+
 void HS_SendHkCmd_Test_ResourceTypeAppMain(void)
 {
     CFE_SB_MsgId_t    TestMsgId;
@@ -367,7 +396,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppMain(void)
     size_t            MsgSize;
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
-    uint32            TableIndex;
+    HS_AppMonState_t *AMStatePtr;
     CFE_ES_TaskInfo_t TaskInfo;
 
     HS_HkTlm_Payload_t *PayloadPtr;
@@ -405,10 +434,13 @@ void HS_SendHkCmd_Test_ResourceTypeAppMain(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     HS_AppData.ExeCountState              = HS_State_ENABLED;
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCTResType_APP_MAIN;
@@ -439,24 +471,18 @@ void HS_SendHkCmd_Test_ResourceTypeAppMain(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
     UtAssert_True(PayloadPtr->ExeCounts[0] == 5, "PayloadPtr->ExeCounts[0] == 5");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_ResourceTypeAppChild(void)
@@ -466,7 +492,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppChild(void)
     size_t            MsgSize;
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
-    uint32            TableIndex;
+    HS_AppMonState_t *AMStatePtr;
     CFE_ES_TaskInfo_t TaskInfo;
     int               i;
 
@@ -503,10 +529,13 @@ void HS_SendHkCmd_Test_ResourceTypeAppChild(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     HS_AppData.ExeCountState              = HS_State_ENABLED;
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCTResType_APP_CHILD;
@@ -537,24 +566,18 @@ void HS_SendHkCmd_Test_ResourceTypeAppChild(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
     UtAssert_True(PayloadPtr->ExeCounts[0] == 5, "PayloadPtr->ExeCounts[0] == 5");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError(void)
@@ -564,7 +587,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError(void)
     size_t            MsgSize;
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
-    uint32            TableIndex;
+    HS_AppMonState_t *AMStatePtr;
     CFE_ES_TaskInfo_t TaskInfo;
     int               i;
 
@@ -601,10 +624,13 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     HS_AppData.ExeCountState              = HS_State_ENABLED;
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCTResType_APP_CHILD;
@@ -636,24 +662,18 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskIdError(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
     UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError(void)
@@ -663,7 +683,7 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError(void)
     size_t            MsgSize;
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
-    uint32            TableIndex;
+    HS_AppMonState_t *AMStatePtr;
     int               i;
 
     HS_HkTlm_Payload_t *PayloadPtr;
@@ -699,10 +719,13 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     HS_AppData.ExeCountState              = HS_State_ENABLED;
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCTResType_APP_CHILD;
@@ -731,24 +754,18 @@ void HS_SendHkCmd_Test_ResourceTypeAppChildTaskInfoError(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
     UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_ResourceTypeDevice(void)
@@ -758,7 +775,7 @@ void HS_SendHkCmd_Test_ResourceTypeDevice(void)
     size_t            MsgSize;
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
-    uint32            TableIndex;
+    HS_AppMonState_t *AMStatePtr;
     CFE_ES_TaskInfo_t TaskInfo;
     int               i;
 
@@ -795,10 +812,13 @@ void HS_SendHkCmd_Test_ResourceTypeDevice(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     HS_AppData.ExeCountState              = HS_State_ENABLED;
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCTResType_DEVICE;
@@ -827,24 +847,18 @@ void HS_SendHkCmd_Test_ResourceTypeDevice(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
     UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_ResourceTypeISR(void)
@@ -854,7 +868,7 @@ void HS_SendHkCmd_Test_ResourceTypeISR(void)
     size_t            MsgSize;
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
-    uint32            TableIndex;
+    HS_AppMonState_t *AMStatePtr;
     int               i;
 
     HS_HkTlm_Payload_t *PayloadPtr;
@@ -890,10 +904,13 @@ void HS_SendHkCmd_Test_ResourceTypeISR(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     HS_AppData.ExeCountState              = HS_State_ENABLED;
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCTResType_ISR;
@@ -916,24 +933,18 @@ void HS_SendHkCmd_Test_ResourceTypeISR(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
     UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_ResourceTypeISRGenCounterError(void)
@@ -943,7 +954,7 @@ void HS_SendHkCmd_Test_ResourceTypeISRGenCounterError(void)
     size_t            MsgSize;
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
-    uint32            TableIndex;
+    HS_AppMonState_t *AMStatePtr;
     int               i;
 
     HS_HkTlm_Payload_t *PayloadPtr;
@@ -979,10 +990,13 @@ void HS_SendHkCmd_Test_ResourceTypeISRGenCounterError(void)
     HS_AppData.EventsMonitoredCount    = 9;
     HS_AppData.MsgActExec              = 10;
 
-    for (TableIndex = 0; TableIndex <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); TableIndex++)
-    {
-        HS_AppData.AppMonEnables[TableIndex] = TableIndex;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     HS_AppData.ExeCountState              = HS_State_ENABLED;
     HS_AppData.XCTablePtr[0].ResourceType = HS_XCTResType_ISR;
@@ -1008,24 +1022,18 @@ void HS_SendHkCmd_Test_ResourceTypeISRGenCounterError(void)
     UtAssert_True(PayloadPtr->InvalidEventMonCount == 0, "PayloadPtr->InvalidEventMonCount == 0");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
 
     UtAssert_True(PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT, "PayloadPtr->ExeCounts[0] == HS_INVALID_EXECOUNT");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_SendHkCmd_Test_ResourceTypeUnknown(void)
@@ -1036,6 +1044,7 @@ void HS_SendHkCmd_Test_ResourceTypeUnknown(void)
     HS_EMTEntry_t     EMTable[HS_MAX_MONITORED_EVENTS];
     HS_XCTEntry_t     XCTable[HS_MAX_EXEC_CNT_SLOTS];
     uint8             ExpectedStatusFlags = 0;
+    HS_AppMonState_t *AMStatePtr;
     int               i;
 
     HS_HkTlm_Payload_t *PayloadPtr;
@@ -1104,22 +1113,16 @@ void HS_SendHkCmd_Test_ResourceTypeUnknown(void)
     UtAssert_True(PayloadPtr->StatusFlags == ExpectedStatusFlags, "PayloadPtr->StatusFlags == ExpectedStatusFlags");
 
     /* Check first, middle, and last element */
-    UtAssert_True(PayloadPtr->AppMonEnables[0] == 0, "PayloadPtr->AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2]
-                      == ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == ((HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE) / 2");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
 
-    UtAssert_True(PayloadPtr->AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE]
-                      == (HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == (HS_MAX_MONITORED_APPS -1) / "
-                  "HS_BITS_PER_APPMON_ENABLE");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 32,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 32",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 32);
 }
 
 void HS_Noop_Test(void)
@@ -1152,10 +1155,7 @@ void HS_Noop_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_ResetCmd_Test(void)
@@ -1188,10 +1188,7 @@ void HS_ResetCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_ResetCounters_Test(void)
@@ -1205,10 +1202,7 @@ void HS_ResetCounters_Test(void)
     UtAssert_True(HS_AppData.EventsMonitoredCount == 0, "HS_AppData.EventsMonitoredCount == 0");
     UtAssert_True(HS_AppData.MsgActExec == 0, "HS_AppData.MsgActExec == 0");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_EnableAppMonCmd_Test(void)
@@ -1252,10 +1246,40 @@ void HS_EnableAppMonCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+}
+
+void HS_EnableAppMonCmd_Test_NotLoaded(void)
+{
+    CFE_SB_MsgId_t    TestMsgId;
+    CFE_MSG_FcnCode_t FcnCode;
+    size_t            MsgSize;
+
+    TestMsgId = CFE_SB_ValueToMsgId(HS_CMD_MID);
+    FcnCode   = HS_ENABLE_APP_MON_CC;
+    MsgSize   = sizeof(UT_CmdBuf.EnableAppMonCmd);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &TestMsgId, sizeof(TestMsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    HS_AppData.AMTablePtr = NULL;
+
+    /* Set to Disabled so the function can freshly set it to Enabled (without it already being set that way) */
+    HS_AppData.CurrentAppMonState = HS_State_DISABLED;
+
+    /* Execute the function being tested */
+    HS_EnableAppMonCmd(&UT_CmdBuf.EnableAppMonCmd);
+
+    /* Verify results */
+    UtAssert_True(HS_AppData.CmdCount == 1, "HS_AppData.CmdCount == 1");
+
+    UtAssert_True(HS_AppData.CurrentAppMonState == HS_State_ENABLED,
+                  "HS_AppData.CurrentAppMonState == HS_State_ENABLED");
+
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_ENABLE_APPMON_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableAppMonCmd_Test_AlreadyEnabled(void)
@@ -1299,10 +1323,7 @@ void HS_EnableAppMonCmd_Test_AlreadyEnabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableAppMonCmd_Test(void)
@@ -1341,10 +1362,7 @@ void HS_DisableAppMonCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableAppMonCmd_Test_AlreadyDisabled(void)
@@ -1385,10 +1403,7 @@ void HS_DisableAppMonCmd_Test_AlreadyDisabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableEventMonCmd_Test_Disabled(void)
@@ -1426,10 +1441,7 @@ void HS_EnableEventMonCmd_Test_Disabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
@@ -1467,10 +1479,7 @@ void HS_EnableEventMonCmd_Test_AlreadyEnabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableEventMonCmd_Test_SubscribeLongError(void)
@@ -1512,10 +1521,7 @@ void HS_EnableEventMonCmd_Test_SubscribeLongError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableEventMonCmd_Test_SubscribeShortError(void)
@@ -1557,10 +1563,7 @@ void HS_EnableEventMonCmd_Test_SubscribeShortError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableEventMonCmd_Test_Enabled(void)
@@ -1598,10 +1601,7 @@ void HS_DisableEventMonCmd_Test_Enabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
@@ -1639,10 +1639,7 @@ void HS_DisableEventMonCmd_Test_AlreadyDisabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableEventMonCmd_Test_UnsubscribeLongError(void)
@@ -1684,10 +1681,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeLongError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableEventMonCmd_Test_UnsubscribeShortError(void)
@@ -1729,10 +1723,7 @@ void HS_DisableEventMonCmd_Test_UnsubscribeShortError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableAlivenessCmd_Test(void)
@@ -1770,10 +1761,7 @@ void HS_EnableAlivenessCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableAlivenessCmd_Test_AlreadyEnabled(void)
@@ -1811,10 +1799,7 @@ void HS_EnableAlivenessCmd_Test_AlreadyEnabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableAlivenessCmd_Test(void)
@@ -1852,10 +1837,7 @@ void HS_DisableAlivenessCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableAlivenessCmd_Test_AlreadyDisabled(void)
@@ -1893,10 +1875,7 @@ void HS_DisableAlivenessCmd_Test_AlreadyDisabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableCpuHogCmd_Test(void)
@@ -1934,10 +1913,7 @@ void HS_EnableCpuHogCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_EnableCpuHogCmd_Test_AlreadyEnabled(void)
@@ -1975,10 +1951,7 @@ void HS_EnableCpuHogCmd_Test_AlreadyEnabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableCpuHogCmd_Test(void)
@@ -2016,10 +1989,7 @@ void HS_DisableCpuHogCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_DisableCpuHogCmd_Test_AlreadyDisabled(void)
@@ -2057,10 +2027,7 @@ void HS_DisableCpuHogCmd_Test_AlreadyDisabled(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_ResetResetsPerformedCmd_Test(void)
@@ -2095,10 +2062,7 @@ void HS_ResetResetsPerformedCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_SetMaxResetsCmd_Test(void)
@@ -2140,10 +2104,7 @@ void HS_SetMaxResetsCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_AcquirePointers_Test_Nominal(void)
@@ -2179,10 +2140,7 @@ void HS_AcquirePointers_Test_Nominal(void)
     UtAssert_True(HS_AppData.MsgActsState == HS_State_ENABLED, "HS_AppData.MsgActsState == HS_State_ENABLED");
     UtAssert_True(HS_AppData.ExeCountState == HS_State_ENABLED, "HS_AppData.ExeCountState == HS_State_ENABLED");
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_AcquirePointers_Test_ErrorsWithAppMonLoadedAndEventMonLoadedEnabled(void)
@@ -2257,10 +2215,7 @@ void HS_AcquirePointers_Test_ErrorsWithAppMonLoadedAndEventMonLoadedEnabled(void
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[3].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 4,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 4",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 4);
 }
 
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled2(void)
@@ -2349,10 +2304,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled2(v
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[4].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 5,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 5",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 5);
 }
 
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled(void)
@@ -2441,10 +2393,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabled(vo
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[4].Spec);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 5,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 5",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 5);
 }
 
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoSubscribeError(void)
@@ -2484,10 +2433,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoS
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, HS_EXECOUNT_GETADDR_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventType, CFE_EVS_EventType_ERROR);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 3,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 3",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
 }
 
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoSubscribeError2(void)
@@ -2527,10 +2473,7 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonAndCurrentEventMonEnabledNoS
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventID, HS_EXECOUNT_GETADDR_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[2].EventType, CFE_EVS_EventType_ERROR);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 3,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 3",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 3);
 }
 
 void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppMonStateDisabled(void)
@@ -2565,25 +2508,25 @@ void HS_AcquirePointers_Test_ErrorsWithCurrentAppMonLoadedDisabledAndCurrentAppM
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_EVENTMON_GETADDR_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
 
 void HS_AppMonStatusRefresh_Test_CycleCountZero(void)
 {
-    HS_AMTEntry_t AMTable[HS_MAX_MONITORED_APPS];
-    uint32        i;
+    HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
+    HS_AppMonState_t *AMStatePtr;
+    uint32            i;
 
     memset(AMTable, 0, sizeof(AMTable));
-
     HS_AppData.AMTablePtr = AMTable;
 
-    for (i = 0; i <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); i++)
-    {
-        HS_AppData.AppMonEnables[i] = 1 + i;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     for (i = 0; i < HS_MAX_MONITORED_APPS; i++)
     {
@@ -2595,43 +2538,40 @@ void HS_AppMonStatusRefresh_Test_CycleCountZero(void)
 
     /* Verify results */
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_ZERO(AMStatePtr->CheckInCountdown);
 
-    UtAssert_True(HS_AppData.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_ZERO(AMStatePtr->CheckInCountdown);
 
-    UtAssert_True(HS_AppData.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] == 0,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_ZERO(AMStatePtr->CheckInCountdown);
 
-    UtAssert_True(HS_AppData.AppMonLastExeCount[0] == 0, "HS_AppData.AppMonLastExeCount[0] == 0");
-    UtAssert_True(HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS / 2] == 0,
-                  "HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS / 2] == 0");
-    UtAssert_UINT32_EQ(HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS - 1], 0);
-
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS / 2] == 0,
-                  "HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS / 2] == 0");
-    UtAssert_UINT16_EQ(HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS - 1], 0);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_AppMonStatusRefresh_Test_ActionTypeNOACT(void)
 {
-    HS_AMTEntry_t AMTable[HS_MAX_MONITORED_APPS];
-    uint32        i;
+    HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
+    HS_AppMonState_t *AMStatePtr;
+    uint32            i;
 
     memset(AMTable, 0, sizeof(AMTable));
-
     HS_AppData.AMTablePtr = AMTable;
 
-    for (i = 0; i <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); i++)
-    {
-        HS_AppData.AppMonEnables[i] = 1 + i;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     for (i = 0; i < HS_MAX_MONITORED_APPS; i++)
     {
@@ -2644,43 +2584,40 @@ void HS_AppMonStatusRefresh_Test_ActionTypeNOACT(void)
 
     /* Verify results */
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_ZERO(AMStatePtr->CheckInCountdown);
 
-    UtAssert_True(HS_AppData.AppMonEnables[((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE) / 2] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_ZERO(AMStatePtr->CheckInCountdown);
 
-    UtAssert_True(HS_AppData.AppMonEnables[(HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE] == 0,
-                  "((HS_MAX_MONITORED_APPS -1) / HS_BITS_PER_APPMON_ENABLE] == 0");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_FALSE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_ZERO(AMStatePtr->CheckInCountdown);
 
-    UtAssert_True(HS_AppData.AppMonLastExeCount[0] == 0, "HS_AppData.AppMonLastExeCount[0] == 0");
-    UtAssert_True(HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS / 2] == 0,
-                  "HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS / 2] == 0");
-    UtAssert_UINT32_EQ(HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS - 1], 0);
-
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS / 2] == 0,
-                  "HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS / 2] == 0");
-    UtAssert_UINT16_EQ(HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS - 1], 0);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_AppMonStatusRefresh_Test_ElseCase(void)
 {
-    HS_AMTEntry_t AMTable[HS_MAX_MONITORED_APPS];
-    uint32        i;
+    HS_AMTEntry_t     AMTable[HS_MAX_MONITORED_APPS];
+    HS_AppMonState_t *AMStatePtr;
+    uint32            i;
 
     memset(AMTable, 0, sizeof(AMTable));
-
     HS_AppData.AMTablePtr = AMTable;
 
-    for (i = 0; i <= ((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE); i++)
-    {
-        HS_AppData.AppMonEnables[i] = 1 + i;
-    }
+    memset(HS_AppData.AppMonState, 0, sizeof(HS_AppData.AppMonState));
+    AMStatePtr         = &HS_AppData.AppMonState[0];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    AMStatePtr->Enable = true;
+    AMStatePtr         = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    AMStatePtr->Enable = true;
 
     for (i = 0; i < HS_MAX_MONITORED_APPS; i++)
     {
@@ -2692,32 +2629,23 @@ void HS_AppMonStatusRefresh_Test_ElseCase(void)
     HS_AppMonStatusRefresh();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonLastExeCount[0] == 0, "HS_AppData.AppMonLastExeCount[0] == 0");
-    UtAssert_True(HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS / 2] == 0,
-                  "HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS / 2] == 0");
-    UtAssert_UINT32_EQ(HS_AppData.AppMonLastExeCount[HS_MAX_MONITORED_APPS - 1], 0);
-
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 1, "HS_AppData.AppMonCheckInCountdown[0] == 1");
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS / 2] == (HS_MAX_MONITORED_APPS / 2) + 1,
-                  "HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS / 2] == (HS_MAX_MONITORED_APPS / 2) + 1");
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS - 1] == (HS_MAX_MONITORED_APPS - 1) + 1,
-                  "HS_AppData.AppMonCheckInCountdown[HS_MAX_MONITORED_APPS] == (HS_MAX_MONITORED_APPS - 1) + 1");
-
     /* Check first, middle, and last element */
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0xFFFFFFFF, "HS_AppData.AppMonEnables[0] == 0xFFFFFFFF");
+    AMStatePtr = &HS_AppData.AppMonState[0];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_UINT32_EQ(AMStatePtr->CheckInCountdown, 1);
 
-    UtAssert_True(
-        HS_AppData.AppMonEnables[(((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) + 1) / 2] == 0xFFFFFFFF,
-        "HS_AppData.AppMonEnables[(((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE)+1) / 2] == 0xFFFFFFFF");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS / 2];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_UINT32_EQ(AMStatePtr->CheckInCountdown, 1 + HS_MAX_MONITORED_APPS / 2);
 
-    UtAssert_True(
-        HS_AppData.AppMonEnables[(((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE) + 1) - 1] == 0xFFFFFFFF,
-        "HS_AppData.AppMonEnables[(((HS_MAX_MONITORED_APPS - 1) / HS_BITS_PER_APPMON_ENABLE)+1) - 1] == 0xFFFFFFFF");
+    AMStatePtr = &HS_AppData.AppMonState[HS_MAX_MONITORED_APPS - 1];
+    UtAssert_BOOL_TRUE(AMStatePtr->Enable);
+    UtAssert_ZERO(AMStatePtr->LastExeCount);
+    UtAssert_UINT32_EQ(AMStatePtr->CheckInCountdown, HS_MAX_MONITORED_APPS);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_MsgActsStatusRefresh_Test(void)
@@ -2726,7 +2654,7 @@ void HS_MsgActsStatusRefresh_Test(void)
 
     for (i = 0; i < HS_MAX_MSG_ACT_TYPES; i++)
     {
-        HS_AppData.MsgActCooldown[i] = 1 + i;
+        HS_AppData.MsgActState[i].Cooldown = 1 + i;
     }
 
     /* Execute the function being tested */
@@ -2736,17 +2664,10 @@ void HS_MsgActsStatusRefresh_Test(void)
     for (i = 0; i < HS_MAX_MSG_ACT_TYPES; i++)
     {
         /* Check first, middle, and last element */
-        UtAssert_True(HS_AppData.MsgActCooldown[0] == 0, "HS_AppData.MsgActCooldown[0] == 0");
-        UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 0,
-                      "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES / 2] == 0");
-        UtAssert_True(HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES - 1] == 0,
-                      "HS_AppData.MsgActCooldown[HS_MAX_MSG_ACT_TYPES -1] == 0");
+        UtAssert_UINT16_EQ(HS_AppData.MsgActState[i].Cooldown, 0);
     }
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
-                  "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 /*
@@ -2766,6 +2687,10 @@ void UtTest_Setup(void)
                HS_Test_Setup,
                HS_Test_TearDown,
                "HS_SendHkCmd_Test_XCTablePtrNullAndDisabled");
+    UtTest_Add(HS_SendHkCmd_Test_XCTablePtrNotNullAndDisabled,
+               HS_Test_Setup,
+               HS_Test_TearDown,
+               "HS_SendHkCmd_Test_XCTablePtrNotNullAndDisabled");
     UtTest_Add(HS_SendHkCmd_Test_ResourceTypeAppMain,
                HS_Test_Setup,
                HS_Test_TearDown,
@@ -2803,6 +2728,7 @@ void UtTest_Setup(void)
 
     UtTest_Add(HS_EnableAppMonCmd_Test, HS_Test_Setup, HS_Test_TearDown, "HS_EnableAppMonCmd_Test");
 
+    UtTest_Add(HS_EnableAppMonCmd_Test_NotLoaded, HS_Test_Setup, HS_Test_TearDown, "HS_EnableAppMonCmd_Test_NotLoaded");
     UtTest_Add(HS_EnableAppMonCmd_Test_AlreadyEnabled,
                HS_Test_Setup,
                HS_Test_TearDown,

--- a/unit-test/hs_monitors_tests.c
+++ b/unit-test/hs_monitors_tests.c
@@ -87,9 +87,9 @@ void HS_MonitorApplications_Test_AppNameNotFound(void)
     HS_AppData.AMTablePtr = AMTable;
 
     /* Element 0 will run through logic with action and not expired */
-    HS_AppData.AMTablePtr[0].ActionType  = -1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = -1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     /* Element 1 has action but expired */
     HS_AppData.AMTablePtr[1].ActionType = -1;
@@ -125,9 +125,9 @@ void HS_MonitorApplications_Test_AppNameNotFoundDebugEvent(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = -1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 2;
+    HS_AppData.AMTablePtr[0].ActionType        = -1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 2;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -156,10 +156,10 @@ void HS_MonitorApplications_Test_GetExeCountFailure(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = -1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 2;
+    HS_AppData.AMTablePtr[0].ActionType        = -1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 2;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -172,10 +172,11 @@ void HS_MonitorApplications_Test_GetExeCountFailure(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 2, "HS_AppData.AppMonCheckInCountdown[0] == 2");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 2,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 2");
 
     /* Execution count does not get updated from AppInfo */
-    UtAssert_True(HS_AppData.AppMonLastExeCount[0] == 0, "HS_AppData.AppMonLastExeCount[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].LastExeCount == 0, "HS_AppData.AppMonState[0].LastExeCount == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
@@ -202,11 +203,11 @@ void HS_MonitorApplications_Test_ProcessorResetError(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_PROC_RESET;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_PROC_RESET;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -222,10 +223,10 @@ void HS_MonitorApplications_Test_ProcessorResetError(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0,
-                  "HS_AppData.AppMonCheckInCountdown[0] == 0 %u",
-                  HS_AppData.AppMonCheckInCountdown[0]);
-    UtAssert_UINT32_EQ(HS_AppData.AppMonEnables[0], 0);
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonState[0].CheckInCountdown == 0 %u",
+                  HS_AppData.AppMonState[0].CheckInCountdown);
+    UtAssert_UINT32_EQ(HS_AppData.AppMonState[0].Enable, 0);
     UtAssert_True(HS_AppData.ServiceWatchdogFlag == HS_State_DISABLED,
                   "HS_AppData.ServiceWatchdogFlag == HS_State_DISABLED");
 
@@ -265,11 +266,11 @@ void HS_MonitorApplications_Test_ProcessorResetActionLimitError(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_PROC_RESET;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_PROC_RESET;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -285,8 +286,9 @@ void HS_MonitorApplications_Test_ProcessorResetActionLimitError(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_PROC_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -328,11 +330,11 @@ void HS_MonitorApplications_Test_RestartAppErrorsGetAppInfoSuccess(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_APP_RESTART;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_APP_RESTART;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -349,8 +351,9 @@ void HS_MonitorApplications_Test_RestartAppErrorsGetAppInfoSuccess(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_RESTART_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -391,11 +394,11 @@ void HS_MonitorApplications_Test_RestartAppErrorsGetAppInfoNotSuccess(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_APP_RESTART;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_APP_RESTART;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
@@ -409,8 +412,9 @@ void HS_MonitorApplications_Test_RestartAppErrorsGetAppInfoNotSuccess(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_RESTART_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -442,11 +446,11 @@ void HS_MonitorApplications_Test_RestartAppRestartSuccess(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_APP_RESTART;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_APP_RESTART;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
@@ -460,8 +464,9 @@ void HS_MonitorApplications_Test_RestartAppRestartSuccess(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_RESTART_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -487,11 +492,11 @@ void HS_MonitorApplications_Test_FailError(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_EVENT;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_EVENT;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -504,8 +509,9 @@ void HS_MonitorApplications_Test_FailError(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_FAIL_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -542,9 +548,9 @@ void HS_MonitorApplications_Test_MsgActsNOACT(void)
 
     HS_AppData.AMTablePtr[0].ActionType =
         HS_AMTActType_NOACT; /* Causes most of the function to be skipped, due to first if-statement */
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
-    HS_AppData.MsgActsState              = HS_State_ENABLED;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.MsgActsState                    = HS_State_ENABLED;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -553,10 +559,10 @@ void HS_MonitorApplications_Test_MsgActsNOACT(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
-    HS_AppData.AppMonLastExeCount[0] = 3;
+    HS_AppData.AppMonState[0].LastExeCount = 3;
 
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.MsgActCooldown[0]         = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
+    HS_AppData.AppMonState[0].Enable     = 1;
+    HS_AppData.MsgActState[0].Cooldown   = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_ENABLED;
     HS_AppData.MATablePtr[0].Cooldown    = 1;
 
@@ -591,9 +597,9 @@ void HS_MonitorApplications_Test_MsgActsNOACTDisabled(void)
 
     HS_AppData.AMTablePtr[0].ActionType =
         HS_AMTActType_NOACT; /* Causes most of the function to be skipped, due to first if-statement */
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
-    HS_AppData.MsgActsState              = HS_State_DISABLED;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.MsgActsState                    = HS_State_DISABLED;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -602,10 +608,10 @@ void HS_MonitorApplications_Test_MsgActsNOACTDisabled(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
-    HS_AppData.AppMonLastExeCount[0] = 3;
+    HS_AppData.AppMonState[0].LastExeCount = 3;
 
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.MsgActCooldown[0]         = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
+    HS_AppData.AppMonState[0].Enable     = 1;
+    HS_AppData.MsgActState[0].Cooldown   = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_ENABLED;
     HS_AppData.MATablePtr[0].Cooldown    = 1;
 
@@ -617,6 +623,43 @@ void HS_MonitorApplications_Test_MsgActsNOACTDisabled(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
                   "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
+}
+
+void HS_MonitorApplications_Test_MsgActsNotLoaded(void)
+{
+    HS_AMTEntry_t    AMTable[HS_MAX_MONITORED_APPS];
+    CFE_ES_AppInfo_t AppInfo;
+
+    memset(AMTable, 0, sizeof(AMTable));
+    memset(&AppInfo, 0, sizeof(AppInfo));
+
+    HS_AppData.AMTablePtr = AMTable;
+    HS_AppData.MATablePtr = NULL;
+
+    strcpy(HS_AppData.AMTablePtr[0].AppName, "ut");
+
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_LAST_NONMSG + 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.MsgActsState                    = HS_State_ENABLED;
+
+    HS_AppData.MsgActsState            = HS_State_ENABLED;
+    HS_AppData.MsgActState[0].Cooldown = 0;
+
+    /* Prevents "failure to get an execution counter" */
+    UT_SetHookFunction(UT_KEY(CFE_ES_GetAppInfo), HS_MONITORS_TEST_CFE_ES_GetAppInfoHook1, &AppInfo);
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
+
+    /* Execute the function being tested */
+    HS_MonitorApplications();
+
+    /* Verify results - this should not do anything because MA table is NULL */
+    UtAssert_ZERO(HS_AppData.MsgActExec);
+    UtAssert_ZERO(HS_AppData.MsgActState[0].Cooldown);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
 
 void HS_MonitorApplications_Test_MsgActsErrorDefault(void)
@@ -644,12 +687,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefault(void)
     HS_AppData.AMTablePtr = AMTable;
     HS_AppData.MATablePtr = MATable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_LAST_NONMSG + 1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
-    HS_AppData.MsgActsState              = HS_State_ENABLED;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_LAST_NONMSG + 1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.MsgActsState                    = HS_State_ENABLED;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -658,7 +701,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefault(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
-    HS_AppData.MsgActCooldown[0]         = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
+    HS_AppData.MsgActState[0].Cooldown   = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_ENABLED;
     HS_AppData.MATablePtr[0].Cooldown    = 1;
 
@@ -666,11 +709,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefault(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_True(HS_AppData.MsgActExec == 1, "HS_AppData.MsgActExec == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 1, "HS_AppData.MsgActCooldown[0] == 1");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 1, "HS_AppData.MsgActState[0].Cooldown == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_MSGACTS_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -705,12 +749,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDisabled(void)
     HS_AppData.AMTablePtr = AMTable;
     HS_AppData.MATablePtr = MATable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_LAST_NONMSG + HS_MAX_MSG_ACT_TYPES + 1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
-    HS_AppData.MsgActsState              = HS_State_ENABLED;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_LAST_NONMSG + HS_MAX_MSG_ACT_TYPES + 1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.MsgActsState                    = HS_State_ENABLED;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -719,7 +763,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDisabled(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
-    HS_AppData.MsgActCooldown[0]         = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
+    HS_AppData.MsgActState[0].Cooldown   = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_ENABLED;
     HS_AppData.MATablePtr[0].Cooldown    = 1;
 
@@ -727,11 +771,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDisabled(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_True(HS_AppData.MsgActExec == 0, "HS_AppData.MsgActExec == 0");
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 0, "HS_AppData.MsgActCooldown[0] == 0");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 0, "HS_AppData.MsgActState[0].Cooldown == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
@@ -758,12 +803,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultCoolDown(void)
     HS_AppData.AMTablePtr = AMTable;
     HS_AppData.MATablePtr = MATable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_LAST_NONMSG + 1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
-    HS_AppData.MsgActsState              = HS_State_ENABLED;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_LAST_NONMSG + 1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.MsgActsState                    = HS_State_ENABLED;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -772,7 +817,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultCoolDown(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
-    HS_AppData.MsgActCooldown[0]         = 1; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
+    HS_AppData.MsgActState[0].Cooldown   = 1; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_ENABLED;
     HS_AppData.MATablePtr[0].Cooldown    = 0;
 
@@ -780,11 +825,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultCoolDown(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_True(HS_AppData.MsgActExec == 0, "HS_AppData.MsgActExec == 0");
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 1, "HS_AppData.MsgActCooldown[0] == 1");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 1, "HS_AppData.MsgActState[0].Cooldown == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
@@ -811,12 +857,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultDisabled(void)
     HS_AppData.AMTablePtr = AMTable;
     HS_AppData.MATablePtr = MATable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_LAST_NONMSG + 1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
-    HS_AppData.MsgActsState              = HS_State_ENABLED;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_LAST_NONMSG + 1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.MsgActsState                    = HS_State_ENABLED;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -825,7 +871,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultDisabled(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
-    HS_AppData.MsgActCooldown[0]         = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
+    HS_AppData.MsgActState[0].Cooldown   = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_DISABLED;
     HS_AppData.MATablePtr[0].Cooldown    = 0;
 
@@ -833,11 +879,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultDisabled(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_True(HS_AppData.MsgActExec == 0, "HS_AppData.MsgActExec == 0s");
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 0, "HS_AppData.MsgActCooldown[0] == 0");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 0, "HS_AppData.MsgActState[0].Cooldown == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
@@ -864,12 +911,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultNoEvent(void)
     HS_AppData.AMTablePtr = AMTable;
     HS_AppData.MATablePtr = MATable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_LAST_NONMSG + 1;
-    HS_AppData.AppMonCheckInCountdown[0] = 1;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
-    HS_AppData.MsgActsState              = HS_State_ENABLED;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_LAST_NONMSG + 1;
+    HS_AppData.AppMonState[0].CheckInCountdown = 1;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
+    HS_AppData.MsgActsState                    = HS_State_ENABLED;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -878,7 +925,7 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultNoEvent(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, CFE_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_SUCCESS);
 
-    HS_AppData.MsgActCooldown[0]         = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
+    HS_AppData.MsgActState[0].Cooldown   = 0; /* (HS_AMTActType_LAST_NONMSG + 1) - HS_AMTActType_LAST_NONMSG - 1 = 0 */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_NOEVENT;
     HS_AppData.MATablePtr[0].Cooldown    = 1;
 
@@ -886,11 +933,12 @@ void HS_MonitorApplications_Test_MsgActsErrorDefaultNoEvent(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 0, "HS_AppData.AppMonCheckInCountdown[0] == 0");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 0, "HS_AppData.AppMonEnables[0] == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 0,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 0");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 0, "HS_AppData.AppMonState[0].Enable == 0");
 
     UtAssert_True(HS_AppData.MsgActExec == 1, "HS_AppData.MsgActExec == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 1, "HS_AppData.MsgActCooldown[0] == 1");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 1, "HS_AppData.MsgActState[0].Cooldown == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
@@ -907,11 +955,11 @@ void HS_MonitorApplications_CheckInCountdownNotZero(void)
 
     HS_AppData.AMTablePtr = AMTable;
 
-    HS_AppData.AMTablePtr[0].ActionType  = HS_AMTActType_EVENT;
-    HS_AppData.AppMonCheckInCountdown[0] = 2;
-    HS_AppData.AppMonLastExeCount[0]     = 0;
-    HS_AppData.AppMonEnables[0]          = 1;
-    HS_AppData.AMTablePtr[0].CycleCount  = 1;
+    HS_AppData.AMTablePtr[0].ActionType        = HS_AMTActType_EVENT;
+    HS_AppData.AppMonState[0].CheckInCountdown = 2;
+    HS_AppData.AppMonState[0].LastExeCount     = 0;
+    HS_AppData.AppMonState[0].Enable           = 1;
+    HS_AppData.AMTablePtr[0].CycleCount        = 1;
 
     strncpy(HS_AppData.AMTablePtr[0].AppName, "AppName", 10);
 
@@ -924,8 +972,9 @@ void HS_MonitorApplications_CheckInCountdownNotZero(void)
     HS_MonitorApplications();
 
     /* Verify results */
-    UtAssert_True(HS_AppData.AppMonCheckInCountdown[0] == 1, "HS_AppData.AppMonCheckInCountdown[0] == 1");
-    UtAssert_True(HS_AppData.AppMonEnables[0] == 1, "HS_AppData.AppMonEnables[0] == 1");
+    UtAssert_True(HS_AppData.AppMonState[0].CheckInCountdown == 1,
+                  "HS_AppData.AppMonCheckInCountdown[0].CheckInCountdown == 1");
+    UtAssert_True(HS_AppData.AppMonState[0].Enable == 1, "HS_AppData.AppMonState[0].Enable == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0,
@@ -1456,6 +1505,38 @@ void HS_MonitorEvent_Test_NoSecondDeleteError(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
+void HS_MonitorEvent_Test_MsgActsNotLoaded(void)
+{
+    HS_EMTEntry_t          EMTable[HS_MAX_MONITORED_APPS];
+    CFE_EVS_LongEventTlm_t Packet;
+
+    memset(EMTable, 0, sizeof(EMTable));
+
+    CFE_MSG_Init((CFE_MSG_Message_t *)&Packet, CFE_SB_ValueToMsgId(HS_CMD_MID), sizeof(CFE_EVS_LongEventTlm_t));
+
+    Packet.Payload.PacketID.EventID = 3;
+
+    HS_AppData.EMTablePtr = EMTable;
+    HS_AppData.MATablePtr = NULL;
+
+    HS_AppData.EMTablePtr[0].ActionType = HS_EMTActType_LAST_NONMSG + 1;
+    HS_AppData.EMTablePtr[0].EventID    = Packet.Payload.PacketID.EventID;
+
+    strcpy(HS_AppData.EMTablePtr[0].AppName, "ut");
+    strcpy(Packet.Payload.PacketID.AppName, "ut");
+
+    HS_AppData.MsgActsState            = HS_State_ENABLED;
+    HS_AppData.MsgActState[0].Cooldown = 0;
+
+    /* Execute the function being tested */
+    HS_MonitorEvent(&Packet);
+
+    /* Verify results - this should not do anything because MA table is NULL */
+    UtAssert_ZERO(HS_AppData.MsgActExec);
+    UtAssert_ZERO(HS_AppData.MsgActState[0].Cooldown);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+}
+
 void HS_MonitorEvent_Test_MsgActsError(void)
 {
     HS_EMTEntry_t          EMTable[HS_MAX_MONITORED_APPS];
@@ -1490,7 +1571,7 @@ void HS_MonitorEvent_Test_MsgActsError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteApp), 1, -1);
 
     HS_AppData.MsgActsState              = HS_State_ENABLED;
-    HS_AppData.MsgActCooldown[0]         = 0;
+    HS_AppData.MsgActState[0].Cooldown   = 0;
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_ENABLED;
     HS_AppData.MATablePtr[0].Cooldown    = 5;
 
@@ -1507,7 +1588,7 @@ void HS_MonitorEvent_Test_MsgActsError(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     UtAssert_True(HS_AppData.MsgActExec == 1, "HS_AppData.MsgActExec == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 5, "HS_AppData.MsgActCooldown[0] == 5");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 5, "HS_AppData.MsgActState[0].Cooldown == 5");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
@@ -1542,8 +1623,8 @@ void HS_MonitorEvent_Test_MsgActsErrorNoEvent(void)
     /* Set CFE_ES_DeleteApp to return -1, in order to generate error message HS_EVENTMON_NOT_DELETED_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteApp), 1, -1);
 
-    HS_AppData.MsgActsState      = HS_State_ENABLED;
-    HS_AppData.MsgActCooldown[0] = 0;
+    HS_AppData.MsgActsState            = HS_State_ENABLED;
+    HS_AppData.MsgActState[0].Cooldown = 0;
 
     /* take branch to avoid HS_EVENTMON_MSGACTS_ERR_EID event error */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_NOEVENT;
@@ -1555,7 +1636,7 @@ void HS_MonitorEvent_Test_MsgActsErrorNoEvent(void)
 
     /* Verify results */
     UtAssert_True(HS_AppData.MsgActExec == 1, "HS_AppData.MsgActExec == 1");
-    UtAssert_True(HS_AppData.MsgActCooldown[0] == 5, "HS_AppData.MsgActCooldown[0] == 5");
+    UtAssert_True(HS_AppData.MsgActState[0].Cooldown == 5, "HS_AppData.MsgActState[0].Cooldown == 5");
 }
 
 void HS_MonitorEvent_Test_MsgActsDefaultDisabled(void)
@@ -1585,8 +1666,8 @@ void HS_MonitorEvent_Test_MsgActsDefaultDisabled(void)
     /* Set CFE_ES_DeleteApp to return -1, in order to generate error message HS_EVENTMON_NOT_DELETED_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteApp), 1, -1);
 
-    HS_AppData.MsgActsState      = HS_State_ENABLED;
-    HS_AppData.MsgActCooldown[0] = 0;
+    HS_AppData.MsgActsState            = HS_State_ENABLED;
+    HS_AppData.MsgActState[0].Cooldown = 0;
 
     /* Execute the function being tested */
     HS_MonitorEvent(&Packet);
@@ -1625,8 +1706,8 @@ void HS_MonitorEvent_Test_MsgActsDefaultGreaterLastNonMsg(void)
     /* Set CFE_ES_DeleteApp to return -1, in order to generate error message HS_EVENTMON_NOT_DELETED_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteApp), 1, -1);
 
-    HS_AppData.MsgActsState      = HS_State_ENABLED;
-    HS_AppData.MsgActCooldown[0] = 0;
+    HS_AppData.MsgActsState            = HS_State_ENABLED;
+    HS_AppData.MsgActState[0].Cooldown = 0;
 
     /* Execute the function being tested */
     HS_MonitorEvent(&Packet);
@@ -1662,8 +1743,8 @@ void HS_MonitorEvent_Test_MsgActsDefaultLessMaxActTypes(void)
     strncpy(HS_AppData.EMTablePtr[0].AppName, "AppName", 10);
     strncpy(Packet.Payload.PacketID.AppName, "AppName", 10);
 
-    HS_AppData.MsgActsState      = HS_State_DISABLED;
-    HS_AppData.MsgActCooldown[0] = 1;
+    HS_AppData.MsgActsState            = HS_State_DISABLED;
+    HS_AppData.MsgActState[0].Cooldown = 1;
 
     /* Execute the function being tested */
     HS_MonitorEvent(&Packet);
@@ -1700,8 +1781,8 @@ void HS_MonitorEvent_Test_MsgActsDefaultMaxActTypes(void)
     strncpy(HS_AppData.EMTablePtr[0].AppName, "AppName", 10);
     strncpy(Packet.Payload.PacketID.AppName, "AppName", 10);
 
-    HS_AppData.MsgActsState                = HS_State_ENABLED;
-    HS_AppData.MsgActCooldown[MsgActIndex] = 0;
+    HS_AppData.MsgActsState                      = HS_State_ENABLED;
+    HS_AppData.MsgActState[MsgActIndex].Cooldown = 0;
 
     /* Execute the function being tested */
     HS_MonitorEvent(&Packet);
@@ -1738,8 +1819,8 @@ void HS_MonitorEvent_Test_MsgActsCoolDown(void)
     strncpy(HS_AppData.EMTablePtr[0].AppName, "AppName", 10);
     strncpy(Packet.Payload.PacketID.AppName, "AppName", 10);
 
-    HS_AppData.MsgActsState      = HS_State_ENABLED;
-    HS_AppData.MsgActCooldown[0] = 1;
+    HS_AppData.MsgActsState            = HS_State_ENABLED;
+    HS_AppData.MsgActState[0].Cooldown = 1;
 
     /* take branch to avoid "Send the message if off cooldown and not disabled" */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_NOEVENT;
@@ -1780,8 +1861,8 @@ void HS_MonitorEvent_Test_MsgActsMATDisabled(void)
     strncpy(HS_AppData.EMTablePtr[0].AppName, "AppName", 10);
     strncpy(Packet.Payload.PacketID.AppName, "AppName", 10);
 
-    HS_AppData.MsgActsState      = HS_State_ENABLED;
-    HS_AppData.MsgActCooldown[0] = 0;
+    HS_AppData.MsgActsState            = HS_State_ENABLED;
+    HS_AppData.MsgActState[0].Cooldown = 0;
 
     /* take branch to avoid "Send the message if off cooldown and not disabled" */
     HS_AppData.MATablePtr[0].EnableState = HS_MATState_DISABLED;
@@ -3110,6 +3191,10 @@ void UtTest_Setup(void)
                HS_Test_Setup,
                HS_Test_TearDown,
                "HS_MonitorApplications_Test_MsgActsNOACTDisabled");
+    UtTest_Add(HS_MonitorApplications_Test_MsgActsNotLoaded,
+               HS_Test_Setup,
+               HS_Test_TearDown,
+               "HS_MonitorApplications_Test_MsgActsNotLoaded");
     UtTest_Add(HS_MonitorApplications_Test_MsgActsErrorDefault,
                HS_Test_Setup,
                HS_Test_TearDown,
@@ -3169,6 +3254,10 @@ void UtTest_Setup(void)
                HS_Test_Setup,
                HS_Test_TearDown,
                "HS_MonitorEvent_Test_NoSecondDeleteError");
+    UtTest_Add(HS_MonitorEvent_Test_MsgActsNotLoaded,
+               HS_Test_Setup,
+               HS_Test_TearDown,
+               "HS_MonitorEvent_Test_MsgActsNotLoaded");
     UtTest_Add(HS_MonitorEvent_Test_MsgActsError, HS_Test_Setup, HS_Test_TearDown, "HS_MonitorEvent_Test_MsgActsError");
     UtTest_Add(HS_MonitorEvent_Test_MsgActsErrorNoEvent,
                HS_Test_Setup,


### PR DESCRIPTION
## Summary

Fix a security issue where a nonexistent application name in the AMT (Application
Monitor Table) triggers the configured failure action, including processor reset.

## Problem

`HS_MonitorSingleApplication` calls `CFE_ES_GetAppIDByName` for each active AMT
entry. When the name lookup fails, the code still falls through to decrement
`CheckInCountdown`. Once the countdown reaches zero, the configured action executes
-- including `PROC_RESET`.

A crafted AMT entry with `AppName = "NONEXISTENT"`, `CycleCount = 1`, and
`ActionType = PROC_RESET` deterministically triggers a processor reset on the
first monitoring cycle after table activation.

Reported in nasa/cFS#1070.

## Fix

Return early from `HS_MonitorSingleApplication` when `CFE_ES_GetAppIDByName`
fails. The error/debug events are still emitted (existing behavior preserved),
but the countdown is not decremented. Only apps that exist and have genuinely
stopped executing will trigger the failure action.

## Testing

The fix is a 6-line change in a single function. The early return preserves
all existing event reporting behavior -- only the countdown decrement path
is guarded.
