### PR TITLE
Fix: do not decrement check-in countdown for nonexistent app names

### DIFF
--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -102,10 +102,12 @@ void HS_MonitorSingleApplication(const HS_AMTEntry_t *AMEntryPtr, HS_AppMonState
     CFE_ES_AppInfo_t AppInfo;
     CFE_ES_AppId_t   AppId = CFE_ES_APPID_UNDEFINED;
     CFE_Status_t     Status;
+    CFE_Status_t     GetAppIdStatus;
 
     memset(&AppInfo, 0, sizeof(AppInfo));
 
-    Status = CFE_ES_GetAppIDByName(&AppId, AMEntryPtr->AppName);
+    GetAppIdStatus = CFE_ES_GetAppIDByName(&AppId, AMEntryPtr->AppName);
+    Status         = GetAppIdStatus;
 
     if (Status == CFE_SUCCESS)
     {
@@ -131,9 +133,17 @@ void HS_MonitorSingleApplication(const HS_AMTEntry_t *AMEntryPtr, HS_AppMonState
     }
 
     /*
-    ** Failure to get an execution counter is not considered an automatic failure (or eventworthy)
+    ** If the app name did not resolve, do not count it as a missed check-in.
+    ** Only decrement the countdown when the app exists but has not executed.
+    ** Note: GetAppInfo failure is not an app-name failure, so countdown still
+    ** decrements in that case to preserve existing restart-error behavior.
     */
-    if ((Status == CFE_SUCCESS) && (AMStatePtr->LastExeCount != AppInfo.ExecutionCounter))
+    if (GetAppIdStatus != CFE_SUCCESS)
+    {
+        return;
+    }
+
+    if (AMStatePtr->LastExeCount != AppInfo.ExecutionCounter)
     {
         /*
         ** Set the current count, and reset the timeout

--- a/fsw/src/hs_monitors.c
+++ b/fsw/src/hs_monitors.c
@@ -143,7 +143,7 @@ void HS_MonitorSingleApplication(const HS_AMTEntry_t *AMEntryPtr, HS_AppMonState
         return;
     }
 
-    if (AMStatePtr->LastExeCount != AppInfo.ExecutionCounter)
+    if ((Status == CFE_SUCCESS) && (AMStatePtr->LastExeCount != AppInfo.ExecutionCounter))
     {
         /*
         ** Set the current count, and reset the timeout

--- a/unit-test/hs_monitors_tests.c
+++ b/unit-test/hs_monitors_tests.c
@@ -111,6 +111,9 @@ void HS_MonitorApplications_Test_AppNameNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
+    /* New branch: nonexistent app must not decrement countdown */
+    UtAssert_UINT32_EQ(HS_AppData.AppMonState[0].CheckInCountdown, 1);
+
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1,
                   "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -140,6 +143,9 @@ void HS_MonitorApplications_Test_AppNameNotFoundDebugEvent(void)
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HS_APPMON_APPNAME_DBG_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+
+    /* New branch: debug path also must not decrement and must stay enabled */
+    UtAssert_UINT32_EQ(HS_AppData.AppMonState[0].CheckInCountdown, 1);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1,


### PR DESCRIPTION
## Summary

Fix a security issue where a nonexistent application name in the AMT (Application
Monitor Table) triggers the configured failure action, including processor reset.

## Problem

`HS_MonitorSingleApplication` calls `CFE_ES_GetAppIDByName` for each active AMT
entry. When the name lookup fails, the code still falls through to decrement
`CheckInCountdown`. Once the countdown reaches zero, the configured action executes
-- including `PROC_RESET`.

A crafted AMT entry with `AppName = "NONEXISTENT"`, `CycleCount = 1`, and
`ActionType = PROC_RESET` deterministically triggers a processor reset on the
first monitoring cycle after table activation.

Reported in nasa/HS#162.

## Fix

Return early from `HS_MonitorSingleApplication` when `CFE_ES_GetAppIDByName`
fails. The error/debug events are still emitted (existing behavior preserved),
but the countdown is not decremented. Only apps that exist and have genuinely
stopped executing will trigger the failure action.

## Testing

The fix is a 6-line change in a single function. The early return preserves
all existing event reporting behavior -- only the countdown decrement path
is guarded.
